### PR TITLE
Cleanup HTTP CLI Registration

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -55,10 +55,15 @@ func CobraBindEnvironmentVariables(prefix string) func(cmd *cobra.Command, _ []s
 }
 
 // RegisterViperFlags registers HTTP flags with Viper CLIs
-func (c *HTTPServerConfig) RegisterViperFlags(flags *pflag.FlagSet, defaultPort int) {
+func (c *HTTPServerConfig) RegisterViperFlags(flags *pflag.FlagSet, defaultPort int, defaultName, version, appPackage, gitSHA string) {
+	c.Version = version
+	c.AppPackage = appPackage
+	c.GitSHA = gitSHA
+	c.Logging.RegisterViperFlags(flags)
+	c.Tracer.RegisterViperFlags(flags, defaultName)
 	flags.StringVarP(&c.Address, "address", "a", "localhost", "Address for server")
 	flags.IntVarP(&c.Port, "port", "p", defaultPort, "Port for server")
-	flags.StringVar(&c.Name, "server-name", c.Name, "Server Name")
+	flags.StringVar(&c.Name, "server-name", defaultName, "Server Name")
 }
 
 // RegisterViperFlags registers Kafka flags with Viper CLIs

--- a/examples/example_server.go
+++ b/examples/example_server.go
@@ -34,12 +34,7 @@ var appPackage = "github.com/spothero/core"
 // of this file, this is how you create and expose your CLI and Environment variables. We're
 // building on the excellent open-source tool Cobra and Viper from spf13
 func newRootCmd(args []string) *cobra.Command {
-	config := &tools.HTTPServerConfig{
-		Name:       "example_server",
-		Version:    version,
-		AppPackage: appPackage,
-		GitSHA:     gitSHA,
-	}
+	config := &tools.HTTPServerConfig{}
 	cmd := &cobra.Command{
 		Use:              "example_server",
 		Short:            "SpotHero Example Golang Microservice",
@@ -53,7 +48,7 @@ func newRootCmd(args []string) *cobra.Command {
 	}
 	// Register default http server flags
 	flags := cmd.Flags()
-	config.CLIRegistration(flags, 8080)
+	config.RegisterViperFlags(flags, 8080, "example_server", version, appPackage, gitSHA)
 	return cmd
 }
 

--- a/http.go
+++ b/http.go
@@ -31,7 +31,6 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 )
 
@@ -66,19 +65,6 @@ type httpMetrics struct {
 // HTTPMetricsRecorder defines an interface for recording prometheus metrics on HTTP requests
 type HTTPMetricsRecorder interface {
 	RecordHttpMetrics(w http.ResponseWriter, r *http.Request) *prometheus.Timer
-}
-
-// CLIRegistration registers required components for all HTTP Servers: Versioning, Logging, Tracing
-func (c *HTTPServerConfig) CLIRegistration(flags *pflag.FlagSet, defaultPort int) {
-	c.RegisterViperFlags(flags, defaultPort)
-
-	// Logging Config
-	c.Logging.AppVersion = c.Version
-	c.Logging.GitSha = c.GitSHA
-	c.Logging.RegisterViperFlags(flags)
-
-	// Tracing Config
-	c.Tracer.RegisterViperFlags(flags, c.Name)
 }
 
 // RunHTTPServer starts and runs a web server, waiting for a cancellation signal to exit


### PR DESCRIPTION
There are a few subtypes that must have their cli registration triggered for our http server to work. This rolls all the logic into one place instead of having it spread amongst a number of function calls.