### PR TITLE
Remove logging sentry config from server

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -55,12 +55,7 @@ func CobraBindEnvironmentVariables(prefix string) func(cmd *cobra.Command, _ []s
 }
 
 // RegisterFlags registers HTTP flags with pflags
-func (c *HTTPServerConfig) RegisterFlags(flags *pflag.FlagSet, defaultPort int, defaultName, version, appPackage, gitSHA string) {
-	c.Version = version
-	c.AppPackage = appPackage
-	c.GitSHA = gitSHA
-	c.Logging.RegisterFlags(flags)
-	c.Tracer.RegisterFlags(flags, defaultName)
+func (c *HTTPServerConfig) RegisterFlags(flags *pflag.FlagSet, defaultPort int, defaultName string) {
 	flags.StringVarP(&c.Address, "address", "a", "localhost", "Address for server")
 	flags.IntVarP(&c.Port, "port", "p", defaultPort, "Port for server")
 	flags.StringVar(&c.Name, "server-name", defaultName, "Server Name")

--- a/examples/example_server.go
+++ b/examples/example_server.go
@@ -48,7 +48,7 @@ func newRootCmd(args []string) *cobra.Command {
 	}
 	// Register default http server flags
 	flags := cmd.Flags()
-	config.RegisterFlags(flags, 8080, "example_server", version, appPackage, gitSHA)
+	config.RegisterFlags(flags, 8080, "example_server")
 	return cmd
 }
 

--- a/http.go
+++ b/http.go
@@ -39,11 +39,6 @@ type HTTPServerConfig struct {
 	Address    string
 	Port       int
 	Name       string
-	Version    string
-	AppPackage string
-	GitSHA     string
-	Logging    LoggingConfig
-	Tracer     TracingConfig
 }
 
 type httpStatusRecorder struct {
@@ -73,10 +68,6 @@ func (c *HTTPServerConfig) RunHTTPServer(
 	postShutdown func(ctx context.Context),
 	registerMuxes func(*http.ServeMux),
 ) {
-	c.Logging.InitializeLogger()
-	closer := c.Tracer.ConfigureTracer()
-	defer closer.Close()
-
 	// Setup a context to send cancellation signals to goroutines
 	ctx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
There's no reason that the http server be attached to tracing or logging config; the user of tools should be able to decide how and when they want to create the logger and tracer.