### PR TITLE
one-liner for a prod-compatible service

### DIFF
--- a/examples/example_server.go
+++ b/examples/example_server.go
@@ -21,47 +21,13 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/opentracing/opentracing-go"
-	"github.com/spf13/cobra"
-	"github.com/spothero/tools"
-	shHTTP "github.com/spothero/tools/http"
-	"github.com/spothero/tools/log"
+	"github.com/spothero/tools/service"
 )
 
 // These variables should be set during build with the Go link tool
 // e.x.: when running go build, provide -ldflags="-X main.version=1.0.0"
 var gitSHA = "not-set"
 var version = "not-set"
-
-// newRootCmd is the entrypoint to your go program. Coupled with the `main` function at the bottom
-// of this file, this is how you create and expose your CLI and Environment variables. We're
-// building on the excellent open-source tool Cobra and Viper from spf13
-func newRootCmd(args []string) *cobra.Command {
-	config := shHTTP.NewDefaultConfig("example_server")
-	config.RegisterHandlers = registerHandlers
-	cmd := &cobra.Command{
-		Use:              "example_server",
-		Short:            "SpotHero Example Golang Microservice",
-		Long:             `The SpotHero Example Golang Microservice shows off the capabilities of our Core library`,
-		Version:          fmt.Sprintf("%s (%s)", version, gitSHA),
-		PersistentPreRun: tools.CobraBindEnvironmentVariables("example_server"),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			lc := &log.Config{
-				UseDevelopmentLogger: true,
-				Fields: map[string]interface{}{
-					"version": version,
-					"git_sha": gitSHA,
-				},
-			}
-			lc.InitializeLogger()
-			config.NewServer().Run()
-			return nil
-		},
-	}
-	// Register default http server flags
-	flags := cmd.Flags()
-	config.RegisterFlags(flags)
-	return cmd
-}
 
 // registerHandlers is a callback used to register HTTP endpoints to the default server
 // NOTE: The HTTP server automatically registers /health and /metrics -- Have a look in your
@@ -96,8 +62,13 @@ func bestLanguage(w http.ResponseWriter, r *http.Request) {
 
 // This is the main entrypoint of the program. Here we create our root command and then execute it.
 func main() {
-	cmd := newRootCmd(os.Args[1:])
-	if err := cmd.Execute(); err != nil {
+	serverCmd := service.HTTPConfig{
+		Name:             "example_server",
+		Version:          version,
+		GitSHA:           gitSHA,
+		RegisterHandlers: registerHandlers,
+	}
+	if err := serverCmd.DefaultServer().Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/examples/example_server.go
+++ b/examples/example_server.go
@@ -68,7 +68,7 @@ func main() {
 		GitSHA:           gitSHA,
 		RegisterHandlers: registerHandlers,
 	}
-	if err := serverCmd.DefaultServer().Execute(); err != nil {
+	if err := serverCmd.ServerCmd().Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/service/http.go
+++ b/service/http.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// HTTPConfig defines service level configuration for HTTP servers
 type HTTPConfig struct {
 	Name             string                                                             // Name of the application server
 	Version          string                                                             // Semantic Version of this Application

--- a/service/http.go
+++ b/service/http.go
@@ -1,0 +1,88 @@
+// Copyright 2019 SpotHero
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/spf13/cobra"
+	"github.com/spothero/tools"
+	shHTTP "github.com/spothero/tools/http"
+	"github.com/spothero/tools/log"
+	"go.uber.org/zap/zapcore"
+)
+
+type HTTPConfig struct {
+	Name             string                                                             // Name of the application server
+	Version          string                                                             // Semantic Version of this Application
+	GitSHA           string                                                             // Git SHA of the compiled Application
+	Address          string                                                             // Address where the server will be acccessible. Default 0.0.0.0
+	Port             int                                                                // Port where the server will be accessible. Default 8080
+	RegisterHandlers func(*mux.Router)                                                  // Router registration callback
+	PreStart         func(ctx context.Context, router *mux.Router, server *http.Server) // Server pre-start callback
+	PostShutdown     func(ctx context.Context)                                          // Server post-shutdown callback
+}
+
+// DefaultServer creates and returns a Cobra and Viper command preconfigured to run a
+// production-quality HTTP server.
+func (hc HTTPConfig) DefaultServer() *cobra.Command {
+	// HTTP Config
+	config := shHTTP.NewDefaultConfig(hc.Name)
+	config.Address = hc.Address
+	if config.Address == "" {
+		config.Address = "0.0.0.0"
+	}
+	config.Port = hc.Port
+	if config.Port == 0 {
+		config.Port = 8080
+	}
+	config.PreStart = hc.PreStart
+	config.PostShutdown = hc.PostShutdown
+	config.RegisterHandlers = hc.RegisterHandlers
+	config.Middleware = shHTTP.Middleware{
+		tools.TracingMiddleware,
+		shHTTP.NewMetrics(hc.Name, nil, true).Middleware,
+		log.LoggingMiddleware,
+	}
+	// Logging Config
+	lc := &log.Config{
+		UseDevelopmentLogger: true,
+		Fields: map[string]interface{}{
+			"version": hc.Version,
+			"git_sha": hc.GitSHA,
+		},
+		Cores: []zapcore.Core{&tools.SentryCore{}},
+	}
+	cmd := &cobra.Command{
+		Use:              hc.Name,
+		Short:            "Starts and runs an HTTP Server",
+		Long:             `Starts and runs an HTTP Server`,
+		Version:          fmt.Sprintf("%s (%s)", hc.Version, hc.GitSHA),
+		PersistentPreRun: tools.CobraBindEnvironmentVariables(hc.Name),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			lc.InitializeLogger()
+			config.NewServer().Run()
+			return nil
+		},
+	}
+	// Register Cobra/Viper CLI Flags
+	flags := cmd.Flags()
+	config.RegisterFlags(flags)
+	lc.RegisterFlags(flags)
+	return cmd
+}

--- a/service/http_test.go
+++ b/service/http_test.go
@@ -1,0 +1,44 @@
+// Copyright 2019 SpotHero
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultServer(t *testing.T) {
+	tests := []struct {
+		name string
+		c    HTTPConfig
+	}{
+		{
+			"when no port or address are specified, 0.0.0.0:8080 is used",
+			HTTPConfig{Address: "", Port: 0, Registry: prometheus.NewRegistry()},
+		},
+		{
+			"when a port and address are specified, they are used",
+			HTTPConfig{Address: "127.0.0.1", Port: 62000, Registry: prometheus.NewRegistry()},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := test.c.ServerCmd()
+			assert.NotNil(t, cmd)
+		})
+	}
+}

--- a/service/http_test.go
+++ b/service/http_test.go
@@ -15,6 +15,7 @@
 package service
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -28,17 +29,39 @@ func TestDefaultServer(t *testing.T) {
 	}{
 		{
 			"when no port or address are specified, 0.0.0.0:8080 is used",
-			HTTPConfig{Address: "", Port: 0, Registry: prometheus.NewRegistry()},
+			HTTPConfig{
+				Name:     "test",
+				Address:  "",
+				Port:     0,
+				Registry: prometheus.NewRegistry(),
+				Version:  "0.1.0",
+				GitSHA:   "abc123",
+			},
 		},
 		{
 			"when a port and address are specified, they are used",
-			HTTPConfig{Address: "127.0.0.1", Port: 62000, Registry: prometheus.NewRegistry()},
+			HTTPConfig{
+				Name:     "test",
+				Address:  "127.0.0.1",
+				Port:     62000,
+				Registry: prometheus.NewRegistry(),
+				Version:  "0.1.0",
+				GitSHA:   "abc123",
+			},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cmd := test.c.ServerCmd()
 			assert.NotNil(t, cmd)
+			assert.NotZero(t, cmd.Use)
+			assert.NotZero(t, cmd.Short)
+			assert.NotZero(t, cmd.Long)
+			assert.True(t, strings.Contains(cmd.Version, test.c.Version))
+			assert.True(t, strings.Contains(cmd.Version, test.c.GitSHA))
+			assert.NotNil(t, cmd.PersistentPreRun)
+			assert.NotNil(t, cmd.Run)
+			assert.True(t, cmd.Flags().HasFlags())
 		})
 	}
 }


### PR DESCRIPTION
@briancharous what do you think of this approach? I think we define one for http, and someday one for grpc. A user could take the two cobra commands and chain them together, as well.