### PR TITLE
use pointer for CLI registration

### DIFF
--- a/http/cli.go
+++ b/http/cli.go
@@ -17,7 +17,7 @@ package http
 import "github.com/spf13/pflag"
 
 // RegisterFlags registers HTTP flags with pflags
-func (c Config) RegisterFlags(flags *pflag.FlagSet) {
+func (c *Config) RegisterFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&c.Name, "server-name", c.Name, "Server Name")
 	flags.StringVarP(&c.Address, "address", "a", c.Address, "Address for server")
 	flags.IntVarP(&c.Port, "port", "p", c.Port, "Port for server")

--- a/log/cli.go
+++ b/log/cli.go
@@ -17,7 +17,7 @@ package log
 import "github.com/spf13/pflag"
 
 // RegisterFlags register Logging flags with pflags
-func (c Config) RegisterFlags(flags *pflag.FlagSet) {
+func (c *Config) RegisterFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&c.UseDevelopmentLogger, "use-development-logger", true, "Whether to use the development logger")
 	flags.StringArrayVar(&c.OutputPaths, "log-output-paths", []string{}, "Log file path for standard logging. Logs always output to stdout.")
 	flags.StringArrayVar(&c.ErrorOutputPaths, "log-error-output-paths", []string{}, "Log file path for error logging. Error logs always output to stderr.")

--- a/log/log.go
+++ b/log/log.go
@@ -58,7 +58,7 @@ func metricsHook(counter *prometheus.CounterVec) func(entry zapcore.Entry) error
 // InitializeLogger sets up the logger. This function should be called as soon
 // as possible. Any use of the logger provided by this package will be a nop
 // until this function is called.
-func (c *Config) InitializeLogger() error {
+func (c Config) InitializeLogger() error {
 	var err error
 	var logConfig zap.Config
 	var level zapcore.Level
@@ -66,7 +66,7 @@ func (c *Config) InitializeLogger() error {
 		c.Encoding = "json"
 	}
 	if err := level.Set(c.Level); err != nil {
-		fmt.Printf("invalid log level %s - using INFO", c.Level)
+		fmt.Printf("invalid log level %s - using INFO\n", c.Level)
 		level = zapcore.InfoLevel
 	}
 	if c.UseDevelopmentLogger {

--- a/sentry/cli.go
+++ b/sentry/cli.go
@@ -17,6 +17,6 @@ package sentry
 import "github.com/spf13/pflag"
 
 // RegisterFlags registers Sentry flags with pflags
-func (c Config) RegisterFlags(flags *pflag.FlagSet) {
+func (c *Config) RegisterFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&c.DSN, "sentry-dsn", "", "Sentry DSN")
 }

--- a/tracing/cli.go
+++ b/tracing/cli.go
@@ -17,7 +17,7 @@ package tracing
 import "github.com/spf13/pflag"
 
 // RegisterFlags registers Tracer flags with pflags
-func (c Config) RegisterFlags(flags *pflag.FlagSet) {
+func (c *Config) RegisterFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&c.Enabled, "tracer-enabled", "t", true, "Enable tracing")
 	flags.StringVar(&c.SamplerType, "tracer-sampler-type", "", "Tracer sampler type")
 	flags.Float64Var(&c.SamplerParam, "tracer-sampler-param", 1.0, "Tracer sampler param")


### PR DESCRIPTION
Without thinking I swapped some of the `RegisterFlags` to non-pointer receivers, which means that modified settings are lost on the command line. Oops.