### PR TITLE
register /debug path to fix pprof profile

### DIFF
--- a/http/server.go
+++ b/http/server.go
@@ -83,6 +83,7 @@ func (c Config) NewServer() Server {
 		router.HandleFunc("/health", healthHandler)
 	}
 	if c.PprofHandler {
+		router.PathPrefix("/debug/").Handler(http.DefaultServeMux)
 		router.PathPrefix("/debug/pprof/").HandlerFunc(pprof.Index)
 		router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
 		router.HandleFunc("/debug/pprof/profile", pprof.Profile)

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -70,7 +70,8 @@ func TestNewServer(t *testing.T) {
 	// walk routes to ensure default routes are registered
 	expectedRoutes := map[string]bool{
 		"/health":              true,
-		"/debug/pprof/":         true,
+		"/debug/":              true,
+		"/debug/pprof/":        true,
 		"/debug/pprof/cmdline": true,
 		"/debug/pprof/profile": true,
 		"/debug/pprof/symbol":  true,


### PR DESCRIPTION
Turns out you have to register `/debug` with `http.DefaultServeMux` or creating profiles (i.e. /debug/pprof/profile) doesn't work and returns 404s.