### PR TITLE
Refactor service startup so that configured flags are accessible downstream

### DIFF
--- a/examples/example_server.go
+++ b/examples/example_server.go
@@ -49,13 +49,15 @@ func (h handler) helloWorld(w http.ResponseWriter, r *http.Request) {
 	defer span.Finish()
 
 	// NOTE: Here we write out some artisanal HTML. There are many other (better) ways to output data.
-	fmt.Fprintf(
-		w, `
+	fmt.Fprintf(w,
+		`
 <html>
 Hello World. What's the <a href='/best-language'>best language?</a></br>
 (I'm running in the %s environment)
 </html>
-`, h.environment)
+		`,
+		h.environment,
+	)
 }
 
 // bestLanguage tells the caller what the best language is. It is inteded for use as an HTTP callback.

--- a/examples/example_server.go
+++ b/examples/example_server.go
@@ -29,23 +29,33 @@ import (
 var gitSHA = "not-set"
 var version = "not-set"
 
+type handler struct {
+	environment string
+}
+
 // registerHandlers is a callback used to register HTTP endpoints to the default server
 // NOTE: The HTTP server automatically registers /health and /metrics -- Have a look in your
 // browser!
-func registerHandlers(router *mux.Router) {
-	router.HandleFunc("/", helloWorld)
+func (h handler) RegisterHandlers(router *mux.Router) {
+	router.HandleFunc("/", h.helloWorld)
 	router.HandleFunc("/best-language", bestLanguage)
 }
 
 // helloWorld simply writes "hello world" to the caller. It is ended for use as an HTTP callback.
-func helloWorld(w http.ResponseWriter, r *http.Request) {
+func (h handler) helloWorld(w http.ResponseWriter, r *http.Request) {
 	// NOTE: This is an example of an opentracing span
 	span, _ := opentracing.StartSpanFromContext(r.Context(), "example-hello-world")
 	span = span.SetTag("Key", "Value")
 	defer span.Finish()
 
 	// NOTE: Here we write out some artisanal HTML. There are many other (better) ways to output data.
-	fmt.Fprintf(w, "<html>Hello World. What's the <a href='/best-language'>best language?</a></html>")
+	fmt.Fprintf(
+		w, `
+<html>
+Hello World. What's the <a href='/best-language'>best language?</a></br>
+(I'm running in the %s environment)
+</html>
+`, h.environment)
 }
 
 // bestLanguage tells the caller what the best language is. It is inteded for use as an HTTP callback.
@@ -57,7 +67,7 @@ func bestLanguage(w http.ResponseWriter, r *http.Request) {
 	defer span.Finish()
 
 	// NOTE: Here we write out some artisanal HTML. There are many other (better) ways to output data.
-	fmt.Fprintf(w, "<html><a href='//golang.org/'>Golang</a>, of course! \\ʕ◔ϖ◔ʔ/</br> Say <a href='/'>hello</a> again.</html>")
+	fmt.Fprintf(w, "<html><a href='//golang.org/'>Go</a>, of course! \\ʕ◔ϖ◔ʔ/</br> Say <a href='/'>hello</a> again.</html>")
 }
 
 // This is the main entrypoint of the program. Here we create our root command and then execute it.
@@ -69,9 +79,12 @@ func main() {
 			GitSHA:      gitSHA,
 			Environment: "local",
 		},
-		RegisterHandlers: registerHandlers,
 	}
-	if err := serverCmd.ServerCmd().Execute(); err != nil {
+	if err := serverCmd.ServerCmd(func(hc service.HTTPConfig) service.HTTPService {
+		return handler{
+			environment: hc.Environment,
+		}
+	}).Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/examples/example_server.go
+++ b/examples/example_server.go
@@ -80,7 +80,7 @@ func main() {
 			Environment: "local",
 		},
 	}
-	if err := serverCmd.ServerCmd(func(hc service.HTTPConfig) service.HTTPService {
+	if err := serverCmd.ServerCmd("", "", func(hc service.HTTPConfig) service.HTTPService {
 		return handler{
 			environment: hc.Environment,
 		}

--- a/service/http.go
+++ b/service/http.go
@@ -50,7 +50,7 @@ type HTTPService interface {
 // at SpotHero. Consumers of the tools libraries are free to define their own server entrypoints if
 // desired. This function is provided as a convenience function that should satisfy most use cases
 // Note that Version and GitSHA *must be specified* before calling this function.
-func (hc HTTPConfig) ServerCmd(newService func(HTTPConfig) HTTPService) *cobra.Command {
+func (hc HTTPConfig) ServerCmd(shortDescript, longDescript string, newService func(HTTPConfig) HTTPService) *cobra.Command {
 	// HTTP Config
 	config := shHTTP.NewDefaultConfig(hc.Name)
 	config.PreStart = hc.PreStart
@@ -78,8 +78,8 @@ func (hc HTTPConfig) ServerCmd(newService func(HTTPConfig) HTTPService) *cobra.C
 	tc := tracing.Config{ServiceName: hc.Name}
 	cmd := &cobra.Command{
 		Use:              hc.Name,
-		Short:            "Starts and runs an HTTP Server",
-		Long:             "Starts and runs an HTTP Server",
+		Short:            shortDescript,
+		Long:             longDescript,
 		Version:          fmt.Sprintf("%s (%s)", hc.Version, hc.GitSHA),
 		PersistentPreRun: cli.CobraBindEnvironmentVariables(hc.Name),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/service/http_test.go
+++ b/service/http_test.go
@@ -18,9 +18,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
+
+type mockService struct{}
+
+func (ms mockService) RegisterHandlers(_ *mux.Router) {}
 
 func TestDefaultServer(t *testing.T) {
 	c := HTTPConfig{
@@ -31,7 +36,7 @@ func TestDefaultServer(t *testing.T) {
 			GitSHA:   "abc123",
 		},
 	}
-	cmd := c.ServerCmd()
+	cmd := c.ServerCmd(func(HTTPConfig) HTTPService { return mockService{} })
 	assert.NotNil(t, cmd)
 	assert.NotZero(t, cmd.Use)
 	assert.NotZero(t, cmd.Short)

--- a/service/http_test.go
+++ b/service/http_test.go
@@ -36,7 +36,7 @@ func TestDefaultServer(t *testing.T) {
 			GitSHA:   "abc123",
 		},
 	}
-	cmd := c.ServerCmd(func(HTTPConfig) HTTPService { return mockService{} })
+	cmd := c.ServerCmd("", "", func(HTTPConfig) HTTPService { return mockService{} })
 	assert.NotNil(t, cmd)
 	assert.NotZero(t, cmd.Use)
 	assert.NotZero(t, cmd.Short)

--- a/service/http_test.go
+++ b/service/http_test.go
@@ -36,7 +36,7 @@ func TestDefaultServer(t *testing.T) {
 			GitSHA:   "abc123",
 		},
 	}
-	cmd := c.ServerCmd("", "", func(HTTPConfig) HTTPService { return mockService{} })
+	cmd := c.ServerCmd("short", "long", func(HTTPConfig) HTTPService { return mockService{} })
 	assert.NotNil(t, cmd)
 	assert.NotZero(t, cmd.Use)
 	assert.NotZero(t, cmd.Short)


### PR DESCRIPTION
 I was running into problems trying to configure a server that needed the environment flag defined by `service.Config` since the `RegisterHandlers` function has to be provided when creating the server cobra command. But, the actual environment value is not actually available until after the service starts up and populates its config from the CLI and/or environment variables.

So, instead of providing the `RegisterHandlers` when configuring a `service.HTTPConfig`, a function to construct the an interface with a `RegisterHandlers` method is provided when creating the server command. Then, the `ServerCmd` method can instantiate the downstream object with its configuration already populated by the CLI and/or environment variables. 