### PR TITLE
Make Kafka logging optional

### DIFF
--- a/kafka/kafka_mock.go
+++ b/kafka/kafka_mock.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
 )
 
 // MockKafkaConsumer implements KafkaConsumerIface for testing purposes
@@ -71,14 +72,14 @@ type MockClient struct {
 }
 
 // NewConsumer creates a new mock consumer
-func (m *MockClient) NewConsumer() (ConsumerIface, error) {
-	args := m.Called()
+func (m *MockClient) NewConsumer(logger *zap.Logger) (ConsumerIface, error) {
+	args := m.Called(logger)
 	return args.Get(0).(ConsumerIface), args.Error(1)
 }
 
 // NewProducer creates a new mock producer
-func (m *MockClient) NewProducer(returnMessages bool) (ProducerIface, error) {
-	args := m.Called(returnMessages)
+func (m *MockClient) NewProducer(logger *zap.Logger, returnMessages bool) (ProducerIface, error) {
+	args := m.Called(logger, returnMessages)
 	return args.Get(0).(ProducerIface), args.Error(1)
 }
 

--- a/kafka/kafka_test.go
+++ b/kafka/kafka_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 // Create a mock message handler
@@ -61,7 +62,11 @@ func setupTestConsumer(t *testing.T, clientGetOffsetReturn int, clientGetOffsetE
 	config := Config{ClientID: "test"}
 	config.initKafkaMetrics(prometheus.NewRegistry())
 	mockClient := &mockSaramaClient{getOffsetReturn: int64(clientGetOffsetReturn), getOffsetErr: clientGetOffsetError}
-	consumer := Consumer{consumer: mockConsumer, Client: Client{Config: config, client: mockClient}}
+	consumer := Consumer{
+		consumer: mockConsumer,
+		Client:   Client{Config: config, client: mockClient},
+		logger:   zap.NewNop(),
+	}
 	return &testHandler{}, consumer, consumer.consumer.(*mocks.Consumer), ctx, cancel
 }
 


### PR DESCRIPTION
This PR makes logging optional because if the user of the Kafka utils wants to handle the errors and log themselves, there are a lot of situations in which this library logging on its own results in duplicate logs.