### PR TITLE
Allow users to store custom logger in ctx

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -115,13 +115,16 @@ func (c Config) InitializeLogger() error {
 	return nil
 }
 
-// NewContext creates and returns a new context with a wrapped logger. If fields are specified,
-// all future invocations of the context logger will include those fields as well. This concept is
+// NewContext creates and returns a new context with a wrapped logger. If a logger is not
+// provided, the context returned will contain the global logger. This concept is
 // useful if you wish for all downstream logs from the site of a given context to include some
-// contextual information. For example, once your application has unpacked the Trace ID, you may
-// wish to log that information with every future request.
-func NewContext(ctx context.Context, fields ...zapcore.Field) context.Context {
-	return context.WithValue(ctx, logKey, Get(ctx).With(fields...))
+// contextual fields or use a sub-logger. For example, once your application has
+// unpacked the Trace ID, you may wish to log that information with every future request.
+func NewContext(ctx context.Context, l *zap.Logger) context.Context {
+	if l == nil {
+		return context.WithValue(ctx, logKey, logger)
+	}
+	return context.WithValue(ctx, logKey, l)
 }
 
 // Get returns the logger wrapped with the given context. This function is intended to be

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -53,28 +53,26 @@ func TestGet(t *testing.T) {
 }
 
 func TestNewContext(t *testing.T) {
+	l := zap.NewNop()
 	tests := []struct {
 		name            string
 		ctx             context.Context
-		fields          []zapcore.Field
+		logger          *zap.Logger
 		expectedOutcome context.Context
 	}{
 		{
-			"no fields leads to a default logger context",
+			"no logger leads to a default logger context",
 			context.Background(),
 			nil,
 			context.WithValue(context.Background(), logKey, logger),
 		}, {
-			"providing fields leads to a new context with a new logger with the provided fields",
+			"providing logger leads to a new context with provided logger",
 			context.Background(),
-			[]zapcore.Field{
-				zap.Int("zero", 0),
-				zap.Int("one", 1),
-			},
+			l.With(zap.Int("zero", 0), zap.Int("one", 1)),
 			context.WithValue(
 				context.Background(),
 				logKey,
-				logger.With(
+				l.With(
 					zap.Int("zero", 0),
 					zap.Int("one", 1),
 				),
@@ -83,7 +81,7 @@ func TestNewContext(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expectedOutcome, NewContext(test.ctx, test.fields...))
+			assert.Equal(t, test.expectedOutcome, NewContext(test.ctx, test.logger))
 		})
 	}
 }

--- a/log/middleware.go
+++ b/log/middleware.go
@@ -32,13 +32,14 @@ import (
 // On outbound response return these attributes include all of the above as well as:
 // * HTTP response code
 func HTTPMiddleware(sr *writer.StatusRecorder, r *http.Request) (func(), *http.Request) {
+	logger := Get(r.Context()).Named("http")
 	method := zap.String("http_method", r.Method)
 	path := zap.String("path", writer.FetchRoutePathTemplate(r))
 	query := zap.String("query_string", r.URL.Query().Encode())
-	Get(r.Context()).Info("request received", method, path, query)
-	Get(r.Context()).Debug("request headers", zap.Reflect("Headers", r.Header))
+	logger.Info("request received", method, path, query)
+	logger.Debug("request headers", zap.Reflect("Headers", r.Header))
 	return func() {
-		Get(r.Context()).Info(
+		logger.Info(
 			"returning response",
 			zap.Int("response_code", sr.StatusCode))
 	}, r


### PR DESCRIPTION
Changes the `NewContext` function in the `log` package to accept a logger instead of fields to allow more customization. For example, one might want to pass a sub-logger or a logger with additional cores or options along inside the context instead of just a logger with pre-determined fields.