### PR TITLE
add option to enforce auth on jwt middleware and default to true

### DIFF
--- a/jose/cli.go
+++ b/jose/cli.go
@@ -20,5 +20,5 @@ import "github.com/spf13/pflag"
 func (c *Config) RegisterFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&c.JSONWebKeySetURL, "jose-jwks-url", c.JSONWebKeySetURL, "JSON Web Key Set (JWKS) URL for JSON Web Token (JWT) Verification")
 	flags.StringVar(&c.ValidIssuer, "jose-valid-issuer", c.ValidIssuer, "Valid issuer (iss) of JWT tokens in this environment")
-	flags.BoolVar(&c.AuthRequired, "jose-auth-required", true, "If true (default), return a 4XX error if the `Authorization` header is missing or invalid. If false, ignores mising `Authorization`.")
+	flags.BoolVar(&c.AuthRequired, "jose-auth-required", true, "If true (default), return a 4XX error if the `Authorization` header is missing or invalid. If false, ignores missing `Authorization`.")
 }

--- a/jose/cli.go
+++ b/jose/cli.go
@@ -20,4 +20,5 @@ import "github.com/spf13/pflag"
 func (c *Config) RegisterFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&c.JSONWebKeySetURL, "jose-jwks-url", c.JSONWebKeySetURL, "JSON Web Key Set (JWKS) URL for JSON Web Token (JWT) Verification")
 	flags.StringVar(&c.ValidIssuer, "jose-valid-issuer", c.ValidIssuer, "Valid issuer (iss) of JWT tokens in this environment")
+	flags.BoolVar(&c.AuthRequired, "jose-auth-required", true, "If true (default), return a 4XX error if the `Authorization` header is missing or invalid. If false, ignores mising `Authorization`.")
 }

--- a/jose/cli_test.go
+++ b/jose/cli_test.go
@@ -36,4 +36,8 @@ func TestRegisterFlags(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "", vi)
 
+	ar, err := flags.GetBool("jose-auth-required")
+	assert.NoError(t, err)
+	assert.True(t, ar)
+
 }

--- a/jose/cli_test.go
+++ b/jose/cli_test.go
@@ -39,5 +39,4 @@ func TestRegisterFlags(t *testing.T) {
 	ar, err := flags.GetBool("jose-auth-required")
 	assert.NoError(t, err)
 	assert.True(t, ar)
-
 }

--- a/jose/jwt.go
+++ b/jose/jwt.go
@@ -32,7 +32,7 @@ type Config struct {
 	// List of one or more claims to be captured from JWTs. If using http middleware,
 	// these generators will determine which claims appear on the context.
 	ClaimGenerators []ClaimGenerator
-	AuthRequired    bool // If true, missing `Authorization` headers will result in a 4xx error
+	AuthRequired    bool // If true, missing/invalid `Authorization` headers will result in a 4xx error
 }
 
 // ClaimGenerator defines an interface which creates a JWT Claim

--- a/jose/jwt.go
+++ b/jose/jwt.go
@@ -32,6 +32,7 @@ type Config struct {
 	// List of one or more claims to be captured from JWTs. If using http middleware,
 	// these generators will determine which claims appear on the context.
 	ClaimGenerators []ClaimGenerator
+	AuthRequired    bool // If true, missing `Authorization` headers will result in a 4xx error
 }
 
 // ClaimGenerator defines an interface which creates a JWT Claim
@@ -62,6 +63,7 @@ type JOSE struct {
 	claimGenerators []ClaimGenerator
 	validIssuer     string
 	jwks            *jose.JSONWebKeySet
+	authRequired    bool
 }
 
 // NewJOSE creates and returns a JOSE client for use.
@@ -91,6 +93,7 @@ func (c Config) NewJOSE() (JOSE, error) {
 		jwks:            jwks,
 		validIssuer:     c.ValidIssuer,
 		claimGenerators: c.ClaimGenerators,
+		authRequired:    c.AuthRequired,
 	}, nil
 }
 

--- a/jose/middleware.go
+++ b/jose/middleware.go
@@ -42,7 +42,7 @@ func GetHTTPMiddleware(jh JOSEHandler, authRequired bool) func(*writer.StatusRec
 			message := "no authorization header found"
 			logger.Debug(message)
 			if authRequired {
-				r.Header.Set("WWW-Authenticate", "Bearer")
+				sr.Header().Set("WWW-Authenticate", "Bearer")
 				http.Error(sr, message, http.StatusUnauthorized)
 			}
 			return func() {}, r
@@ -52,7 +52,7 @@ func GetHTTPMiddleware(jh JOSEHandler, authRequired bool) func(*writer.StatusRec
 			message := "authorization header did not include bearer prefix"
 			logger.Debug(message)
 			if authRequired {
-				r.Header.Set("WWW-Authenticate", "Bearer")
+				sr.Header().Set("WWW-Authenticate", "Bearer")
 				http.Error(sr, message, http.StatusUnauthorized)
 			}
 			return func() {}, r

--- a/jose/middleware_test.go
+++ b/jose/middleware_test.go
@@ -15,6 +15,7 @@
 package jose
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -135,7 +136,12 @@ func TestGetHTTPMiddleware(t *testing.T) {
 			assert.NotNil(t, r)
 
 			if test.authRequired {
-				assert.Equal(t, sr.StatusCode, test.expectedStatusCode)
+				httpRespResult := recorder.Result()
+				assert.Equal(t, test.expectedStatusCode, httpRespResult.StatusCode)
+				for expectedHeader, expectedValue := range test.expectedHeaders {
+					fmt.Printf("%+v\n", httpRespResult)
+					assert.Equal(t, expectedValue, httpRespResult.Header.Get(expectedHeader))
+				}
 			}
 			value, ok := r.Context().Value(MockClaimKey).(*MockClaim)
 			if test.expectClaim {


### PR DESCRIPTION
By default, auth is enforced on JWT middleware. Missing bearer token == `401` if `Authorization` is missing or the `Bearer <token>` bit is malformed. `403` if the token is present but invalid.