### PR TITLE
Sentry middleware

### DIFF
--- a/sentry/core.go
+++ b/sentry/core.go
@@ -233,7 +233,7 @@ func Hub(hub *sentry.Hub) zapcore.Field {
 }
 
 // MarshalLogObject implements Zap's ObjectMarshaler interface but is a no-op
-// since we don't actually want add anything from the Sentry Hub to the log.
+// since we don't actually want to add anything from the Sentry Hub to the log.
 func (f hubZapField) MarshalLogObject(_ zapcore.ObjectEncoder) error {
 	return nil
 }

--- a/sentry/middleware.go
+++ b/sentry/middleware.go
@@ -8,6 +8,10 @@ import (
 	"github.com/spothero/tools/log"
 )
 
+// This middleware is a wrapper around the sentry-go library's middleware that attaches a the Sentry hub that
+// from the request context to the logger. That way, if the logger ever writes an error log, instead of just sending
+// the log message and fields provided to the logger to Sentry, Sentry is able to capture the entire request context
+// i.e. the request path, headers present, etc.
 func HTTPMiddleware(next http.Handler) http.Handler {
 	sentryHandler := sentryhttp.New(sentryhttp.Options{
 		Repanic:         true,

--- a/sentry/middleware.go
+++ b/sentry/middleware.go
@@ -26,7 +26,7 @@ func HTTPMiddleware(next http.Handler) http.Handler {
 		hub.ConfigureScope(func(scope *sentry.Scope) {
 			span := opentracing.SpanFromContext(r.Context())
 			if sc, ok := span.Context().(jaeger.SpanContext); ok {
-				scope.SetExtra("trace_id", sc.TraceID().String())
+				scope.SetTag("trace_id", sc.TraceID().String())
 			}
 		})
 		ctx := log.NewContext(r.Context(), log.Get(r.Context()).With(Hub(hub)))

--- a/sentry/middleware.go
+++ b/sentry/middleware.go
@@ -5,13 +5,16 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	sentryhttp "github.com/getsentry/sentry-go/http"
+	"github.com/opentracing/opentracing-go"
 	"github.com/spothero/tools/log"
+	"github.com/uber/jaeger-client-go"
 )
 
 // This middleware is a wrapper around the sentry-go library's middleware that attaches a the Sentry hub that
 // from the request context to the logger. That way, if the logger ever writes an error log, instead of just sending
 // the log message and fields provided to the logger to Sentry, Sentry is able to capture the entire request context
-// i.e. the request path, headers present, etc.
+// i.e. the request path, headers present, etc. If this middleware is attached after the tracing middleware,
+// the corresponding Trace ID will be added to the Sentry scope.
 func HTTPMiddleware(next http.Handler) http.Handler {
 	sentryHandler := sentryhttp.New(sentryhttp.Options{
 		Repanic:         true,
@@ -20,6 +23,12 @@ func HTTPMiddleware(next http.Handler) http.Handler {
 	})
 	return sentryHandler.HandleFunc(func(w http.ResponseWriter, r *http.Request) {
 		hub := sentry.GetHubFromContext(r.Context())
+		hub.ConfigureScope(func(scope *sentry.Scope) {
+			span := opentracing.SpanFromContext(r.Context())
+			if sc, ok := span.Context().(jaeger.SpanContext); ok {
+				scope.SetTag("trace_id", sc.TraceID().String())
+			}
+		})
 		ctx := log.NewContext(r.Context(), log.Get(r.Context()).With(Hub(hub)))
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/sentry/middleware.go
+++ b/sentry/middleware.go
@@ -1,0 +1,22 @@
+package sentry
+
+import (
+	"net/http"
+
+	"github.com/getsentry/sentry-go"
+	sentryhttp "github.com/getsentry/sentry-go/http"
+	"github.com/spothero/tools/log"
+)
+
+func HTTPMiddleware(next http.Handler) http.Handler {
+	sentryHandler := sentryhttp.New(sentryhttp.Options{
+		Repanic:         true,
+		WaitForDelivery: true,
+		Timeout:         flushTimeout,
+	})
+	return sentryHandler.HandleFunc(func(w http.ResponseWriter, r *http.Request) {
+		hub := sentry.GetHubFromContext(r.Context())
+		ctx := log.NewContext(r.Context(), log.Get(r.Context()).With(Hub(hub)))
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/sentry/middleware.go
+++ b/sentry/middleware.go
@@ -26,7 +26,7 @@ func HTTPMiddleware(next http.Handler) http.Handler {
 		hub.ConfigureScope(func(scope *sentry.Scope) {
 			span := opentracing.SpanFromContext(r.Context())
 			if sc, ok := span.Context().(jaeger.SpanContext); ok {
-				scope.SetTag("trace_id", sc.TraceID().String())
+				scope.SetExtra("trace_id", sc.TraceID().String())
 			}
 		})
 		ctx := log.NewContext(r.Context(), log.Get(r.Context()).With(Hub(hub)))

--- a/sentry/middleware_test.go
+++ b/sentry/middleware_test.go
@@ -22,7 +22,7 @@ func TestHTTPMiddleware(t *testing.T) {
 		assert.NotEqual(t, clone.Scope(), hub.Scope())
 	})
 
-	testServer := httptest.NewServer(tracing.HTTPMiddleware(HTTPMiddleware(testHandler)))
+	testServer := httptest.NewServer(tracing.HTTPMiddleware(NewMiddleware().HTTP(testHandler)))
 	defer testServer.Close()
 	res, err := http.Get(testServer.URL)
 	require.NoError(t, err)

--- a/sentry/middleware_test.go
+++ b/sentry/middleware_test.go
@@ -1,0 +1,31 @@
+package sentry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/spothero/tools/tracing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPMiddleware(t *testing.T) {
+	testHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		assert.True(t, sentry.HasHubOnContext(r.Context()))
+		hub := sentry.GetHubFromContext(r.Context())
+		// there's no way to get the contents of scope, so just make sure the hub isn't empty to verify the
+		// trace id is on it
+		clone := hub.Clone()
+		clone.Scope().Clear()
+		assert.NotEqual(t, clone.Scope(), hub.Scope())
+	})
+
+	testServer := httptest.NewServer(tracing.HTTPMiddleware(HTTPMiddleware(testHandler)))
+	defer testServer.Close()
+	res, err := http.Get(testServer.URL)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	res.Body.Close()
+}

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -14,9 +14,34 @@
 
 package sentry
 
-import "github.com/spf13/pflag"
+import (
+	"github.com/getsentry/sentry-go"
+	"github.com/spf13/pflag"
+)
+
+// Config defines the necessary configuration for instantiating a Sentry Reporter
+type Config struct {
+	DSN         string
+	Environment string
+	AppVersion  string
+}
 
 // RegisterFlags registers Sentry flags with pflags
 func (c *Config) RegisterFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&c.DSN, "sentry-dsn", "", "Sentry DSN")
+}
+
+// InitializeSentry Initializes the Sentry client. This function should be called as soon as
+// possible after the application configuration is loaded so that sentry
+// is setup.
+func (c Config) InitializeSentry() error {
+	opts := sentry.ClientOptions{
+		Dsn:         c.DSN,
+		Environment: c.Environment,
+		Release:     c.AppVersion,
+	}
+	if err := sentry.Init(opts); err != nil {
+		return err
+	}
+	return nil
 }

--- a/service/http.go
+++ b/service/http.go
@@ -60,7 +60,7 @@ func (hc HTTPConfig) ServerCmd(shortDescript, longDescript string, newService fu
 		tracing.HTTPMiddleware,
 		shHTTP.NewMetrics(hc.Registry, true).Middleware,
 		log.HTTPMiddleware,
-		sentry.HTTPMiddleware,
+		sentry.NewMiddleware().HTTP,
 	}
 	// Logging Config
 	lc := &log.Config{

--- a/service/http.go
+++ b/service/http.go
@@ -60,6 +60,7 @@ func (hc HTTPConfig) ServerCmd(shortDescript, longDescript string, newService fu
 		tracing.HTTPMiddleware,
 		shHTTP.NewMetrics(hc.Registry, true).Middleware,
 		log.HTTPMiddleware,
+		sentry.HTTPMiddleware,
 	}
 	// Logging Config
 	lc := &log.Config{


### PR DESCRIPTION
This puts the Sentry recovery middleware back in place and amends the logger so that error logs that get sent to Sentry are much richer since they have request metadata. Sentry also captures the opentracing trace ID if possible and adds it to the downstream Sentry scope.