### PR TITLE
process remaining middleware if auth is not required

### DIFF
--- a/jose/middleware.go
+++ b/jose/middleware.go
@@ -29,10 +29,11 @@ const authHeader = "Authorization"
 const bearerPrefix = "Bearer "
 
 const (
-	authHeaderNotFound = "no authorization header found"
+	authHeaderNotFound   = "no authorization header found"
 	bearerPrefixNotFound = "authorization header did not include bearer prefix"
-	invalidBearerToken = "bearer token is invalid"
-	)
+	invalidBearerToken   = "bearer token is invalid"
+)
+
 // GetHTTPMiddleware returns an HTTP middleware function which extracts the Authorization header,
 // if present, on all incoming HTTP requests. If an Authorization header is found, this middleware
 // attempts to parse and validate that value as a JWT with  the configured Credential types for

--- a/jose/middleware.go
+++ b/jose/middleware.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/spothero/tools/log"
-	"go.uber.org/zap"
 )
 
 // authHeader defines the name of the header containing the JWT authorization data
@@ -29,6 +28,11 @@ const authHeader = "Authorization"
 // Eg `Authorization: Bearer <JWT>`
 const bearerPrefix = "Bearer "
 
+const (
+	authHeaderNotFound = "no authorization header found"
+	bearerPrefixNotFound = "authorization header did not include bearer prefix"
+	invalidBearerToken = "bearer token is invalid"
+	)
 // GetHTTPMiddleware returns an HTTP middleware function which extracts the Authorization header,
 // if present, on all incoming HTTP requests. If an Authorization header is found, this middleware
 // attempts to parse and validate that value as a JWT with  the configured Credential types for
@@ -38,42 +42,46 @@ func GetHTTPMiddleware(jh JOSEHandler, authRequired bool) func(next http.Handler
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			logger := log.Get(r.Context())
 			authHeader := r.Header.Get(authHeader)
+			var parseErrMsg string
 			if len(authHeader) == 0 {
-				message := "no authorization header found"
-				logger.Debug(message)
-				if authRequired {
-					w.Header().Set("WWW-Authenticate", "Bearer")
-					http.Error(w, message, http.StatusUnauthorized)
+				logger.Debug(authHeaderNotFound)
+				parseErrMsg = authHeaderNotFound
+			}
+
+			if len(parseErrMsg) == 0 && !strings.HasPrefix(authHeader, bearerPrefix) {
+				logger.Debug(bearerPrefixNotFound)
+				parseErrMsg = bearerPrefixNotFound
+			}
+
+			var claims []Claim
+			if len(parseErrMsg) == 0 {
+				claims = jh.GetClaims()
+				bearerToken := strings.TrimPrefix(authHeader, bearerPrefix)
+				err := jh.ParseValidateJWT(bearerToken, claims...)
+				if err != nil {
+					logger.Debug(err.Error())
+					parseErrMsg = invalidBearerToken
 				}
-				return
 			}
-
-			if !strings.HasPrefix(authHeader, bearerPrefix) {
-				message := "authorization header did not include bearer prefix"
-				logger.Debug(message)
-				if authRequired {
-					w.Header().Set("WWW-Authenticate", "Bearer")
-					http.Error(w, message, http.StatusUnauthorized)
+			if len(parseErrMsg) == 0 {
+				// Populate each claim on the context, if any
+				for _, claim := range claims {
+					r = r.WithContext(claim.NewContext(r.Context()))
 				}
-				return
 			}
 
-			claims := jh.GetClaims()
-			bearerToken := strings.TrimPrefix(authHeader, bearerPrefix)
-			err := jh.ParseValidateJWT(bearerToken, claims...)
-			if err != nil {
-				logger.Debug("failed to parse and/or validate Bearer token", zap.Error(err))
+			if len(parseErrMsg) != 0 {
+				logger.Debug(parseErrMsg)
 				if authRequired {
-					http.Error(w, "bearer token is invalid", http.StatusForbidden)
+					httpStatus := http.StatusForbidden
+					if parseErrMsg == bearerPrefixNotFound || parseErrMsg == authHeaderNotFound {
+						w.Header().Set("WWW-Authenticate", "Bearer")
+						httpStatus = http.StatusUnauthorized
+					}
+					http.Error(w, parseErrMsg, httpStatus)
+					return
 				}
-				return
 			}
-
-			// Populate each claim on the context, if any
-			for _, claim := range claims {
-				r = r.WithContext(claim.NewContext(r.Context()))
-			}
-
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/jose/middleware_test.go
+++ b/jose/middleware_test.go
@@ -27,15 +27,15 @@ import (
 
 func TestGetHTTPMiddleware(t *testing.T) {
 	tests := []struct {
-		name               string
-		authHeaderPresent  bool
-		authHeader         string
-		jwt                string
-		parseJWTError      bool
-		expectClaim        bool
-		authRequired       bool
-		expectedStatusCode int
-		expectedHeaders    map[string]string
+		name                    string
+		authHeaderPresent       bool
+		authHeader              string
+		jwt                     string
+		parseJWTError           bool
+		expectClaim             bool
+		authRequired            bool
+		expectedStatusCode      int
+		expectedHeaders         map[string]string
 		expectNextHandlerCalled bool
 	}{
 		{

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -47,7 +47,6 @@ type ProducerIface interface {
 	Errors() chan *sarama.ProducerError
 }
 
-
 // Constant values that represent the required acks setting for produced messages. These map to
 // the sarama.RequiredAcks constants
 const (
@@ -63,7 +62,7 @@ const (
 type ProducerConfig struct {
 	ProducerCompressionCodec string
 	ProducerCompressionLevel int
-	ProducerRequiredAcks int
+	ProducerRequiredAcks     int
 }
 
 // Registers producer flags with pflags


### PR DESCRIPTION
currently, if auth is not required and the auth header fails to parse, the request processing short circuits and returns a 200 with no response body. This PR refactors the auth token parsing to short circuit if auth is required, but still allow further processing if it is not required.