### PR TITLE
Add other tasks' help descriptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,17 @@ GIT_SHA ?= $(shell git rev-parse HEAD)
 LINTER_INSTALLED := $(shell sh -c 'which golangci-lint')
 
 .PHONY: all
-all: lint test
+all: lint test ## Lints and runs the tests
 
 .PHONY: build
-build: example-server jwt-cli
+build: example-server jwt-cli ## Builds the project
 
 .PHONY: example-server
-example-server:
+example-server: ## Builds an example server
 	go build -ldflags="-X main.version=${VERSION} -X main.gitSHA=${GIT_SHA}" -o example-server examples/http/server.go
 
 .PHONY: jwt-cli
-jwt-cli:
+jwt-cli: ## Builds a jwt cli
 	go build -ldflags="-X main.version=${VERSION} -X main.gitSHA=${GIT_SHA}" -o jwt-cli examples/jose/jwt.go
 
 .PHONY: test


### PR DESCRIPTION
I ran `make help` and I did not find the `build` target listed in the
help menu. I thought this project does not have it, but after checking
the `Makefile`, I found that target.

This change provides help menu text for all other Makefile targets.

Before:
```
% make help
coverage                       Displays test coverage report
help                           Prints this help command
lint                           Runs the go code linter
test                           Runs application tests
```

After:
```
% make help
all                            Lints and runs the tests
build                          Builds the project
coverage                       Displays test coverage report
example-server                 Builds an example server
help                           Prints this help command
jwt-cli                        Builds a jwt cli
lint                           Runs the go code linter
test                           Runs application tests
```