### PR TITLE
Http query parsers

### DIFF
--- a/http/parsers.go
+++ b/http/parsers.go
@@ -26,6 +26,13 @@ type Coordinates struct {
 	longitude float64
 }
 
+// ParseCoordinates reads and parses from from the query parameters to the
+// supplied the supplied request latitude and logitude corresponding to
+// latFieldName and lonFieldName, respectively. An error is returned if only
+// one of the named fields is present, if either value cannot be parsed as a
+// float, or if either value is out of range for decimal latitude and
+// longitude. The returned struct reference is nil if none of latFieldName or
+// lonFieldName are present in the query parameters to the given request.
 func ParseCoordinates(r *http.Request, latFieldName, lonFieldName string) (*Coordinates, error) {
 	r.ParseForm()
 	latStr := r.Form.Get(latFieldName)
@@ -70,6 +77,11 @@ func ParseCoordinates(r *http.Request, latFieldName, lonFieldName string) (*Coor
 	}
 }
 
+// ParseTime reads and parses from the query parameters to the supplied request
+// a Time value corresponding to fieldName. An error is returned if a Time
+// could not be parsed from the given field. The zero-valued Time is returned
+// if the given field is not present in the query parameters to the supplied
+// request.
 func ParseTime(r *http.Request, fieldName string) (time.Time, error) {
 	r.ParseForm()
 	fieldStr := r.Form.Get(fieldName)

--- a/http/parsers.go
+++ b/http/parsers.go
@@ -21,6 +21,8 @@ import (
 	"time"
 )
 
+// Coordinates is an encapsulation of geospatial coordinates in decimal
+// degrees.
 type Coordinates struct {
 	latitude  float64
 	longitude float64

--- a/http/parsers.go
+++ b/http/parsers.go
@@ -15,10 +15,11 @@
 package http
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 	"time"
+
+	"golang.org/x/xerrors"
 )
 
 // Coordinates is an encapsulation of geospatial coordinates in decimal
@@ -49,7 +50,7 @@ func ParseCoordinates(r *http.Request, latFieldName, lonFieldName string) (*Coor
 		// case: some value supplied for latitude
 		_lat, errLat := strconv.ParseFloat(latStr, 64)
 		if errLat != nil {
-			return nil, fmt.Errorf("unable to parse %v", latFieldName)
+			return nil, xerrors.Errorf("unable to parse %v", latFieldName)
 		}
 		lat = _lat
 		latPresent = true
@@ -59,27 +60,26 @@ func ParseCoordinates(r *http.Request, latFieldName, lonFieldName string) (*Coor
 		// case: some value supplied for longitude
 		_lon, errLat := strconv.ParseFloat(lonStr, 64)
 		if errLat != nil {
-			return nil, fmt.Errorf("unable to parse %v", lonFieldName)
+			return nil, xerrors.Errorf("unable to parse %v", lonFieldName)
 		}
 		lon = _lon
 		lonPresent = true
 	}
 
 	if lat < -90 || lat > 90 {
-		return nil, fmt.Errorf("%v must be in [-90, 90]", latFieldName)
+		return nil, xerrors.Errorf("%v must be in [-90, 90]", latFieldName)
 	}
 
 	if lon < -180 || lon > 180 {
-		return nil, fmt.Errorf("%v must be in [-180, 180]", lonFieldName)
+		return nil, xerrors.Errorf("%v must be in [-180, 180]", lonFieldName)
 	}
 
-	if latPresent && lonPresent {
-		return &Coordinates{lat, lon}, nil
-	} else if latPresent != lonPresent {
-		return nil, fmt.Errorf("both %v and %v must be provided", latFieldName, lonFieldName)
-	} else {
+	if latPresent != lonPresent {
+		return nil, xerrors.Errorf("both %v and %v must be provided", latFieldName, lonFieldName)
+	} else if !latPresent && !lonPresent {
 		return nil, nil
 	}
+	return &Coordinates{lat, lon}, nil
 }
 
 // ParseTime reads and parses from the query parameters to the supplied request
@@ -93,16 +93,16 @@ func ParseTime(r *http.Request, fieldName string) (time.Time, error) {
 	}
 
 	fieldStr := r.Form.Get(fieldName)
-	if fieldStr != "" {
-		parsed, err := time.Parse(time.RFC3339, fieldStr)
-
-		if err != nil {
-			err = fmt.Errorf("unable to parse `%v`: %v", fieldName, parsed)
-			return time.Time{}, err
-		}
-
-		return parsed, nil
+	if fieldStr == "" {
+		return time.Time{}, nil
 	}
 
-	return time.Time{}, nil
+	parsed, err := time.Parse(time.RFC3339, fieldStr)
+
+	if err != nil {
+		err = xerrors.Errorf("unable to parse `%v`: %v", fieldName, parsed)
+		return time.Time{}, err
+	}
+
+	return parsed, nil
 }

--- a/http/parsers.go
+++ b/http/parsers.go
@@ -1,0 +1,84 @@
+// Copyright 2019 SpotHero
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type Coordinates struct {
+	latitude  float64
+	longitude float64
+}
+
+func ParseCoordinates(r *http.Request, latFieldName, lonFieldName string) (*Coordinates, error) {
+	latStr := r.Form.Get(latFieldName)
+	lonStr := r.Form.Get(lonFieldName)
+	coordsPresent := false
+	var lat, lon float64
+
+	if latStr != "" {
+		// case: some value supplied for latitude
+		_lat, errLat := strconv.ParseFloat(latStr, 64)
+		if errLat != nil {
+			return nil, fmt.Errorf("unable to parse %v", latFieldName)
+		}
+		lat = _lat
+		coordsPresent = true
+	}
+
+	if lonStr != "" {
+		// case: some value supplied for longitude
+		_lon, errLat := strconv.ParseFloat(lonStr, 64)
+		if errLat != nil {
+			return nil, fmt.Errorf("unable to parse %v", lonFieldName)
+		}
+		lon = _lon
+		coordsPresent = true
+	}
+
+	if lat < 90 || lat > 90 {
+		return nil, fmt.Errorf("%v must be in [90, 90]", lonFieldName)
+	}
+
+	if lon < 180 || lon > 180 {
+		return nil, fmt.Errorf("%v must be in [180, 180]", lonFieldName)
+	}
+
+	if coordsPresent {
+		return &Coordinates{lat, lon}, nil
+	} else {
+		return nil, nil
+	}
+}
+
+func ParseTime(r *http.Request, fieldName string) (time.Time, error) {
+	fieldStr := r.Form.Get(fieldName)
+	if fieldStr != "" {
+		parsed, err := time.Parse(time.RFC3339, fieldStr)
+
+		if err != nil {
+			err = fmt.Errorf("unable to parse `%v`: %v", fieldName, parsed)
+			return time.Time{}, err
+		}
+
+		return parsed, nil
+	}
+
+	return time.Time{}, nil
+}

--- a/http/parsers.go
+++ b/http/parsers.go
@@ -36,7 +36,10 @@ type Coordinates struct {
 // struct reference is nil if none of latFieldName or lonFieldName are present
 // in the query parameters to the given request.
 func ParseCoordinates(r *http.Request, latFieldName, lonFieldName string) (*Coordinates, error) {
-	r.ParseForm()
+	if err := r.ParseForm(); err != nil {
+		return nil, err
+	}
+
 	latStr := r.Form.Get(latFieldName)
 	lonStr := r.Form.Get(lonFieldName)
 	latPresent, lonPresent := false, false
@@ -85,7 +88,10 @@ func ParseCoordinates(r *http.Request, latFieldName, lonFieldName string) (*Coor
 // if the given field is not present in the query parameters to the supplied
 // request.
 func ParseTime(r *http.Request, fieldName string) (time.Time, error) {
-	r.ParseForm()
+	if err := r.ParseForm(); err != nil {
+		return time.Time{}, err
+	}
+
 	fieldStr := r.Form.Get(fieldName)
 	if fieldStr != "" {
 		parsed, err := time.Parse(time.RFC3339, fieldStr)

--- a/http/parsers.go
+++ b/http/parsers.go
@@ -28,13 +28,13 @@ type Coordinates struct {
 	longitude float64
 }
 
-// ParseCoordinates reads and parses from from the query parameters to the
-// supplied the supplied request latitude and logitude corresponding to
-// latFieldName and lonFieldName, respectively. An error is returned if only
-// one of the named fields is present, if either value cannot be parsed as a
-// float, or if either value is out of range for decimal latitude and
-// longitude. The returned struct reference is nil if none of latFieldName or
-// lonFieldName are present in the query parameters to the given request.
+// ParseCoordinates reads and parses from the query parameters to the supplied
+// request latitude and logitude corresponding to latFieldName and
+// lonFieldName, respectively. An error is returned if only one of the named
+// fields is present, if either value cannot be parsed as a float, or if either
+// value is out of range for decimal latitude and longitude. The returned
+// struct reference is nil if none of latFieldName or lonFieldName are present
+// in the query parameters to the given request.
 func ParseCoordinates(r *http.Request, latFieldName, lonFieldName string) (*Coordinates, error) {
 	r.ParseForm()
 	latStr := r.Form.Get(latFieldName)

--- a/http/parsers.go
+++ b/http/parsers.go
@@ -24,8 +24,8 @@ import (
 // Coordinates is an encapsulation of geospatial coordinates in decimal
 // degrees.
 type Coordinates struct {
-	latitude  float64
-	longitude float64
+	Latitude  float64
+	Longitude float64
 }
 
 // ParseCoordinates reads and parses from the query parameters to the supplied

--- a/http/parsers_test.go
+++ b/http/parsers_test.go
@@ -1,0 +1,25 @@
+// Copyright 2019 SpotHero
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTest(t *testing.T) {
+	assert.Equal(t, true, false)
+}

--- a/http/parsers_test.go
+++ b/http/parsers_test.go
@@ -15,11 +15,213 @@
 package http
 
 import (
+	"fmt"
+	"net/http"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTest(t *testing.T) {
-	assert.Equal(t, true, false)
+func TestParseCoordinates(t *testing.T) {
+	tests := []struct {
+		name         string
+		url          string
+		latFieldName string
+		lonFieldName string
+		coords       *Coordinates
+		errStr       string
+	}{
+		{
+			"Typical success",
+			"https://example.com/?lat=10&lon=10",
+			"lat",
+			"lon",
+			&Coordinates{10.0, 10.0},
+			"",
+		},
+		{
+			"Missing latitude",
+			"https://example.com/?lon=10",
+			"lat",
+			"lon",
+			nil,
+			"both lat and lon must be provided",
+		},
+		{
+			"Missing longitude",
+			"https://example.com/?lat=10",
+			"lat",
+			"lon",
+			nil,
+			"both lat and lon must be provided",
+		},
+		{
+			"Unparceable latitude",
+			"https://example.com/?lat=ten&lon=10",
+			"lat",
+			"lon",
+			nil,
+			"unable to parse lat",
+		},
+		{
+			"Unparceable longitude",
+			"https://example.com/?lat=10&lon=ten",
+			"lat",
+			"lon",
+			nil,
+			"unable to parse lon",
+		},
+		{
+			"Latitude at the margin",
+			"https://example.com/?lat=-90&lon=10",
+			"lat",
+			"lon",
+			&Coordinates{-90, 10},
+			"",
+		},
+		{
+			"Latitude at the margin",
+			"https://example.com/?lat=90&lon=10",
+			"lat",
+			"lon",
+			&Coordinates{90, 10},
+			"",
+		},
+		{
+			"Latitude out of range",
+			"https://example.com/?lat=-90.1&lon=10",
+			"lat",
+			"lon",
+			nil,
+			"lat must be in [-90, 90]",
+		},
+		{
+			"Latitude out of range",
+			"https://example.com/?lat=90.1&lon=10",
+			"lat",
+			"lon",
+			nil,
+			"lat must be in [-90, 90]",
+		},
+		{
+			"Longitude at the margin",
+			"https://example.com/?lat=-10&lon=-180",
+			"lat",
+			"lon",
+			&Coordinates{-10, -180},
+			"",
+		},
+		{
+			"Longitude at the margin",
+			"https://example.com/?lat=-10&lon=180",
+			"lat",
+			"lon",
+			&Coordinates{-10, 180},
+			"",
+		},
+		{
+			"Longitude out of range",
+			"https://example.com/?lat=10&lon=-180.1",
+			"lat",
+			"lon",
+			nil,
+			"lon must be in [-180, 180]",
+		},
+		{
+			"Longitude out of range",
+			"https://example.com/?lat=10&lon=180.1",
+			"lat",
+			"lon",
+			nil,
+			"lon must be in [-180, 180]",
+		},
+		{
+			"Differently named latitude param",
+			"https://example.com/?foo=10&lon=10",
+			"foo",
+			"lon",
+			&Coordinates{10, 10},
+			"",
+		},
+		{
+			"Differently named longitude param",
+			"https://example.com/?lat=10&bar=10",
+			"lat",
+			"bar",
+			&Coordinates{10, 10},
+			"",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			r, _ := http.NewRequest(http.MethodGet, test.url, strings.NewReader(""))
+			maybeCoords, err := ParseCoordinates(r, test.latFieldName, test.lonFieldName)
+			assert.True((err == nil && test.errStr == "") || err != nil && err.Error() == test.errStr)
+			assert.Equal(test.coords, maybeCoords)
+		})
+	}
+}
+
+func TestParseTime(t *testing.T) {
+	buildTime := func(isoStr string) time.Time {
+		time, err := time.Parse(time.RFC3339, isoStr)
+		if err != nil {
+			panic(fmt.Sprintf("Could not parse as RFC3339: %v", isoStr))
+		}
+
+		return time
+	}
+
+	tests := []struct {
+		name      string
+		url       string
+		fieldName string
+		result    time.Time
+		err       bool
+	}{
+		{
+			"Basic success",
+			"https://example.com/?time=2019-10-07T15:07:39-05:00",
+			"time",
+			buildTime("2019-10-07T15:07:39-05:00"),
+			false,
+		},
+		{
+			"Differently named field",
+			"https://example.com/?foobar=2019-10-07T15:07:39-05:00",
+			"foobar",
+			buildTime("2019-10-07T15:07:39-05:00"),
+			false,
+		},
+		{
+			"Unparseable time",
+			"https://example.com/?time=bogus",
+			"time",
+			time.Time{},
+			true,
+		},
+		{
+			"Field missing from query",
+			"https://example.com/",
+			"time",
+			time.Time{},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			r, _ := http.NewRequest(http.MethodGet, test.url, strings.NewReader(""))
+			maybeTime, err := ParseTime(r, test.fieldName)
+			assert.True((err == nil) != test.err)
+			assert.Equal(test.result, maybeTime)
+		})
+	}
 }


### PR DESCRIPTION
This PR introduces reusable query parameter parsers, specifically:

- ParseCoordinates
- ParseTime

@briancharous @greg-mclain just CCing you in on this PR as tools users