### PR TITLE
Adds MySQL wrapper w/middleware & removes named query requirement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/gchaincl/sqlhooks v1.1.0
 	github.com/getsentry/sentry-go v0.3.0
+	github.com/go-sql-driver/mysql v1.4.1
 	github.com/gorilla/mux v1.7.1
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmoiron/sqlx v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/go-sql-driver/mysql v1.4.0 h1:7LxgVwFb2hIQtMm87NdgAVfXjnt4OePseqT1tKx+opk=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
+github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=

--- a/log/middleware_test.go
+++ b/log/middleware_test.go
@@ -121,16 +121,6 @@ func TestSQLMiddleware(t *testing.T) {
 			1,
 			true,
 		},
-		{
-			"unnamed logs are warned on in the end middleware",
-			zapcore.DebugLevel,
-			"",
-			"test-query",
-			2,
-			1,
-			0,
-			false,
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/log/middleware_test.go
+++ b/log/middleware_test.go
@@ -121,6 +121,16 @@ func TestSQLMiddleware(t *testing.T) {
 			1,
 			true,
 		},
+		{
+			"unnamed queries are still logged in the end middleware",
+			zapcore.DebugLevel,
+			"",
+			"test-query",
+			1,
+			1,
+			0,
+			false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -133,7 +143,10 @@ func TestSQLMiddleware(t *testing.T) {
 
 			// Set expectations
 			expectedLevel := test.logLevel
-			expectedLabels := []string{"query_name", "query"}
+			expectedLabels := []string{"query"}
+			if test.queryName != "" {
+				expectedLabels = append(expectedLabels, "query_name")
+			}
 			expectedLabelsEnd := expectedLabels
 			if test.numErrLogsEndExpect > 0 {
 				expectedLevel = zapcore.ErrorLevel

--- a/sql/metrics.go
+++ b/sql/metrics.go
@@ -16,9 +16,9 @@ package sql
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spothero/tools/log"
 	"github.com/spothero/tools/sql/middleware"
@@ -180,7 +180,7 @@ func newMetrics(dbName string, registry prometheus.Registerer, mustRegister bool
 
 // exportMetrics creates a goroutine which periodically scrapes the core database driver for
 // connection details, exporting those metrics for prometheus scraping
-func (m metrics) exportMetrics(db *sqlx.DB, frequency time.Duration) chan<- bool {
+func (m metrics) exportMetrics(db *sql.DB, frequency time.Duration) chan<- bool {
 	ticker := time.NewTicker(frequency)
 	kill := make(chan bool)
 	labels := prometheus.Labels{"db_name": m.dbName}

--- a/sql/metrics_test.go
+++ b/sql/metrics_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/jmoiron/sqlx"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
@@ -82,7 +81,7 @@ func TestExportMetrics(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotPanics(t, func() {
 		metrics := newMetrics("test", nil, false)
-		cancelChannel := metrics.exportMetrics(&sqlx.DB{DB: db, Mapper: nil}, 5*time.Millisecond)
+		cancelChannel := metrics.exportMetrics(db, 5*time.Millisecond)
 		timer := time.NewTimer(10 * time.Millisecond)
 		<-timer.C
 		cancelChannel <- true

--- a/sql/middleware/middleware.go
+++ b/sql/middleware/middleware.go
@@ -16,7 +16,6 @@ package middleware
 
 import (
 	"context"
-	"fmt"
 )
 
 // ctxCallbackKey is the type used to place the list of middleware within context.Context
@@ -76,10 +75,7 @@ func (m Middleware) OnError(ctx context.Context, queryErr error, query string, a
 
 // end provides a common function for closing out SQL query middleware
 func (m Middleware) end(ctx context.Context, queryErr error, query string, args ...interface{}) (context.Context, error) {
-	queryName, ok := ctx.Value(ctxQueryNameValue).(string)
-	if !ok {
-		return ctx, fmt.Errorf("no query name found on SQL query")
-	}
+	queryName, _ := ctx.Value(ctxQueryNameValue).(string)
 	mwEndCallbacks, ok := ctx.Value(ctxCallbackValue).([]MiddlewareEnd)
 	if !ok {
 		return ctx, nil

--- a/sql/middleware/middleware_test.go
+++ b/sql/middleware/middleware_test.go
@@ -133,12 +133,6 @@ func TestEnd(t *testing.T) {
 			true,
 			true,
 		},
-		{
-			"missing query name results in an error",
-			1,
-			false,
-			false,
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/sql/middleware/middleware_test.go
+++ b/sql/middleware/middleware_test.go
@@ -71,6 +71,12 @@ func TestBefore(t *testing.T) {
 			true,
 			true,
 		},
+		{
+			"missing query name is handled",
+			2,
+			false,
+			false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -133,6 +139,12 @@ func TestEnd(t *testing.T) {
 			true,
 			true,
 		},
+		{
+			"missing query name is handled",
+			2,
+			false,
+			false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -147,7 +159,7 @@ func TestEnd(t *testing.T) {
 			}
 			ctx = context.WithValue(ctx, ctxCallbackValue, mw)
 			ctx, err := Middleware{}.end(ctx, nil, "query", "arg1", "arg2")
-			if test.expectErr || !test.supplyQueryName {
+			if test.expectErr {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)

--- a/sql/middleware/middleware_test.go
+++ b/sql/middleware/middleware_test.go
@@ -71,12 +71,6 @@ func TestBefore(t *testing.T) {
 			true,
 			true,
 		},
-		{
-			"missing query name is handled",
-			2,
-			false,
-			false,
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/sql/mysql.go
+++ b/sql/mysql.go
@@ -1,0 +1,51 @@
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/gchaincl/sqlhooks"
+	"github.com/go-sql-driver/mysql"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spothero/tools/log"
+	"go.uber.org/zap"
+
+	"github.com/spothero/tools/sql/middleware"
+)
+
+const wrappedMySQLDriverName = "wrappedMySQL"
+
+// NewWrappedMySQLDrive builds a MySQL driver wrapped with the provided middleware and starts
+// a periodic task that collects database connection metrics in the provided prometheus registerer.
+// The returned function should be called close the database connection instead of calling Close()
+// directly as it stops the periodic metrics task.
+func NewWrappedMySQL(
+	ctx context.Context,
+	config mysql.Config,
+	middleware middleware.Middleware,
+	registry prometheus.Registerer,
+	mustRegister bool,
+	collectionFrequency time.Duration,
+) (*sql.DB, func() error, error) {
+	stdLogger, err := zap.NewStdLogAt(log.Get(ctx).Named("mysql"), zap.ErrorLevel)
+	if err != nil {
+		log.Get(ctx).Error(
+			"mysql driver errors will be output to stderr because the standard logger failed to build",
+			zap.Error(err))
+	} else {
+		// this can only ever error if the logger is nil, but that can only happen if the
+		// standard logger failed to build
+		_ = mysql.SetLogger(stdLogger)
+	}
+	sql.Register(wrappedMySQLDriverName, sqlhooks.Wrap(mysql.MySQLDriver{}, &middleware))
+	db, err := sql.Open(wrappedMySQLDriverName, config.FormatDSN())
+	if err != nil {
+		return nil, nil, err
+	}
+	metricsChannel := newMetrics(config.DBName, registry, mustRegister).exportMetrics(db, collectionFrequency)
+	return db, func() error {
+		close(metricsChannel)
+		return db.Close()
+	}, nil
+}

--- a/sql/postgres.go
+++ b/sql/postgres.go
@@ -159,7 +159,7 @@ func (pc PostgresConfig) Connect(ctx context.Context, registry prometheus.Regist
 		zap.String("host", pc.Host),
 		zap.Uint16("port", pc.Port),
 	)
-	dbMetricsChannel := newMetrics(pc.Database, registry, mustRegister).exportMetrics(db, pc.MetricsFrequency)
+	dbMetricsChannel := newMetrics(pc.Database, registry, mustRegister).exportMetrics(db.DB, pc.MetricsFrequency)
 	return db, func() {
 		dbMetricsChannel <- true
 		db.Close()

--- a/tracing/middleware.go
+++ b/tracing/middleware.go
@@ -115,9 +115,11 @@ func SQLMiddleware(ctx context.Context, queryName, query string, args ...interfa
 		spanName = fmt.Sprintf("%s_%s", spanName, queryName)
 	}
 	span, spanCtx := opentracing.StartSpanFromContext(ctx, spanName)
-	span = span.SetTag("component", "tracing")
-	span = span.SetTag("db.type", "sql")
-	span = span.SetTag("db.statement", query)
+	span = span.
+		SetTag("component", "tracing").
+		SetTag("db.type", "sql").
+		SetTag("db.statement", query).
+		SetTag("db.statement.arguments", args)
 	mwEnd := func(ctx context.Context, queryName, query string, queryErr error, args ...interface{}) (context.Context, error) {
 		defer span.Finish()
 		if queryErr != nil {


### PR DESCRIPTION
* Adds a wrapped MySQL db connection so that MySQL database interactions can be wrapped with the same tracing, logging, and metrics as the Postgres wrapper
* Makes naming queries optional so that the wrappers can be used with libraries other than sqlx (including the standard library sql module) that don't necessarily accept a context for database operations.