### PR TITLE
Instrument the GRPC server and make request received log at Debug

### DIFF
--- a/log/grpc_interceptors.go
+++ b/log/grpc_interceptors.go
@@ -37,7 +37,7 @@ func UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.Una
 	ctx = setLogCtx(ctx, info.FullMethod, startTime)
 	requestLogger := Get(ctx)
 	logger := requestLogger.Named("grpc")
-	logger.Info("request received")
+	logger.Debug("request received")
 	newCtx := NewContext(ctx, requestLogger)
 	resp, err := handler(newCtx, req)
 	code := status.Code(err)
@@ -59,7 +59,7 @@ func StreamServerInterceptor(srv interface{}, stream grpc.ServerStream, info *gr
 	ctx := setLogCtx(stream.Context(), info.FullMethod, startTime)
 	requestLogger := Get(ctx)
 	logger := requestLogger.Named("grpc")
-	logger.Info("request received")
+	logger.Debug("request received")
 	newCtx := NewContext(ctx, requestLogger)
 	wrapped := grpc_middleware.WrapServerStream(stream)
 	wrapped.WrappedContext = newCtx

--- a/log/grpc_interceptors_test.go
+++ b/log/grpc_interceptors_test.go
@@ -70,7 +70,7 @@ func verifyRequestResponseLogs(t *testing.T, recordedLogs *observer.ObservedLogs
 }
 
 func TestUnaryServerInterceptor(t *testing.T) {
-	recordedLogs := makeLoggerObservable(t, zapcore.InfoLevel)
+	recordedLogs := makeLoggerObservable(t, zapcore.DebugLevel)
 	ctx := context.Background()
 	info := &grpc.UnaryServerInfo{}
 	mockHandler := func(ctx context.Context, req interface{}) (interface{}, error) {
@@ -83,7 +83,7 @@ func TestUnaryServerInterceptor(t *testing.T) {
 }
 
 func TestStreamServerInterceptor(t *testing.T) {
-	recordedLogs := makeLoggerObservable(t, zapcore.InfoLevel)
+	recordedLogs := makeLoggerObservable(t, zapcore.DebugLevel)
 	info := &grpc.StreamServerInfo{}
 	mockHandler := func(srv interface{}, stream grpc.ServerStream) error {
 		return nil

--- a/log/log.go
+++ b/log/log.go
@@ -1,6 +1,4 @@
-// Copyright 2019 SpotHero
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
+// Copyright 2019 SpotHero // // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
@@ -18,6 +16,7 @@ import (
 	"context"
 	"fmt"
 
+	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -112,6 +111,7 @@ func (c Config) InitializeLogger() error {
 	if logger, err = logConfig.Build(c.Options...); err != nil {
 		return fmt.Errorf("error initializing logger - %s", err.Error())
 	}
+	grpc_zap.ReplaceGrpcLoggerV2(logger)
 	return nil
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -1,4 +1,6 @@
-// Copyright 2019 SpotHero // // Licensed under the Apache License, Version 2.0 (the "License");
+// Copyright 2019 SpotHero
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //

--- a/log/middleware.go
+++ b/log/middleware.go
@@ -42,7 +42,7 @@ func HTTPMiddleware(next http.Handler) http.Handler {
 		method := zap.String("http_method", r.Method)
 		path := zap.String("path", writer.FetchRoutePathTemplate(r))
 		query := zap.String("query_string", r.URL.Query().Encode())
-		logger.Debug("request received", method, path, query, zap.Reflect("Headers", r.Header))
+		logger.Debug("request received", method, path, query)
 		defer func() {
 			var responseCodeField zap.Field
 			if statusRecorder, ok := w.(*writer.StatusRecorder); ok {

--- a/log/middleware.go
+++ b/log/middleware.go
@@ -42,8 +42,7 @@ func HTTPMiddleware(next http.Handler) http.Handler {
 		method := zap.String("http_method", r.Method)
 		path := zap.String("path", writer.FetchRoutePathTemplate(r))
 		query := zap.String("query_string", r.URL.Query().Encode())
-		logger.Info("request received", method, path, query)
-		logger.Debug("request headers", zap.Reflect("Headers", r.Header))
+		logger.Debug("request received", method, path, query, zap.Reflect("Headers", r.Header))
 		defer func() {
 			var responseCodeField zap.Field
 			if statusRecorder, ok := w.(*writer.StatusRecorder); ok {

--- a/log/middleware_test.go
+++ b/log/middleware_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestHTTPMiddleware(t *testing.T) {
-	recordedLogs := makeLoggerObservable(t, zapcore.InfoLevel)
+	recordedLogs := makeLoggerObservable(t, zapcore.DebugLevel)
 
 	// setup a test server with logging middleware and a handler that sets the status code
 	const statusCode = 666
@@ -50,6 +50,7 @@ func TestHTTPMiddleware(t *testing.T) {
 	for idx, field := range currLogs[0].Context {
 		foundLogKeysRequest[idx] = field.Key
 	}
+	fmt.Println(foundLogKeysRequest)
 	assert.ElementsMatch(t, []string{"http_method", "path", "query_string"}, foundLogKeysRequest)
 
 	// Test that response parameters are appropriately logged to our standards


### PR DESCRIPTION
* Replaces the GRPC logger with our zap logger
* Makes `request received` log messages Debug, as we discussed, to cut down on excess logging