### PR TITLE
Service pre-start and post-shutdown functionality

### DIFF
--- a/grpc/server_test.go
+++ b/grpc/server_test.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"syscall"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
@@ -146,17 +145,14 @@ func TestRun(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			timer := time.NewTimer(20 * time.Millisecond)
-			go func() {
-				<-timer.C
-				assert.NoError(t, syscall.Kill(syscall.Getpid(), syscall.SIGUSR1))
-			}()
-			err := test.server.Run()
+			done, err := test.server.Run()
 			if test.expectErr {
 				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
+				return
 			}
+			assert.NoError(t, err)
+			assert.NoError(t, syscall.Kill(syscall.Getpid(), syscall.SIGUSR1))
+			<-done
 		})
 	}
 }

--- a/service/cli.go
+++ b/service/cli.go
@@ -25,14 +25,17 @@ import (
 
 // Config defines service level configuration for HTTP servers
 type Config struct {
-	Name          string                                             // Name of the application
-	Environment   string                                             // Environment where the server is running
-	Version       string                                             // Semantic Version of the application
-	GitSHA        string                                             // GitSHA of the application when compiled
-	Registry      prometheus.Registerer                              // The Prometheus Registry to use. If nil, the global registry is used by default.
-	CancelSignals []os.Signal                                        // OS Signals to be used to cancel running servers. Defaults to SIGINT/`os.Interrupt`.
-	PreStart      func(ctx context.Context) (context.Context, error) // A function to be called before starting the service
-	PostShutdown  func(ctx context.Context) error                    // A function to be called before stopping the service
+	Name          string                // Name of the application
+	Environment   string                // Environment where the server is running
+	Version       string                // Semantic Version of the application
+	GitSHA        string                // GitSHA of the application when compiled
+	Registry      prometheus.Registerer // The Prometheus Registry to use. If nil, the global registry is used by default.
+	CancelSignals []os.Signal           // OS Signals to be used to cancel running servers. Defaults to SIGINT/`os.Interrupt`.
+
+	// A function to be called before starting the service. The context passed into the ServerCmd function will be
+	// fed all the way through PreStart and into PostShutdown, enabling communication of state through these functions.
+	PreStart     func(ctx context.Context) (context.Context, error)
+	PostShutdown func(ctx context.Context) error // A function to be called before stopping the service
 }
 
 // RegisterFlags registers Service flags with pflags

--- a/service/cli.go
+++ b/service/cli.go
@@ -25,14 +25,14 @@ import (
 
 // Config defines service level configuration for HTTP servers
 type Config struct {
-	Name          string                          // Name of the application
-	Environment   string                          // Environment where the server is running
-	Version       string                          // Semantic Version of the application
-	GitSHA        string                          // GitSHA of the application when compiled
-	Registry      prometheus.Registerer           // The Prometheus Registry to use. If nil, the global registry is used by default.
-	CancelSignals []os.Signal                     // OS Signals to be used to cancel running servers. Defaults to SIGINT/`os.Interrupt`.
-	PreStart      func(ctx context.Context) error // A function to be called before starting the service
-	PostShutdown  func(ctx context.Context) error // A function to be called before stopping the service
+	Name          string                                             // Name of the application
+	Environment   string                                             // Environment where the server is running
+	Version       string                                             // Semantic Version of the application
+	GitSHA        string                                             // GitSHA of the application when compiled
+	Registry      prometheus.Registerer                              // The Prometheus Registry to use. If nil, the global registry is used by default.
+	CancelSignals []os.Signal                                        // OS Signals to be used to cancel running servers. Defaults to SIGINT/`os.Interrupt`.
+	PreStart      func(ctx context.Context) (context.Context, error) // A function to be called before starting the service
+	PostShutdown  func(ctx context.Context) error                    // A function to be called before stopping the service
 }
 
 // RegisterFlags registers Service flags with pflags

--- a/service/cli.go
+++ b/service/cli.go
@@ -16,25 +16,23 @@ package service
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 	"strings"
 
-	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/pflag"
 )
 
 // Config defines service level configuration for HTTP servers
 type Config struct {
-	Name             string                                                             // Name of the application
-	Environment      string                                                             // Environment where the server is running
-	Version          string                                                             // Semantic Version of the application
-	GitSHA           string                                                             // GitSHA of the application when compiled
-	Registry         prometheus.Registerer                                              // The Prometheus Registry to use. If nil, the global registry is used by default.
-	CancelSignals    []os.Signal                                                        // OS Signals to be used to cancel running servers. Defaults to SIGINT/`os.Interrupt`.
-	PreStartHTTP     func(ctx context.Context, router *mux.Router, server *http.Server) // A function to be called before starting the HTTP web server
-	PostShutdownHTTP func(ctx context.Context)                                          // A function to be called before stopping the HTTP web server
+	Name          string                          // Name of the application
+	Environment   string                          // Environment where the server is running
+	Version       string                          // Semantic Version of the application
+	GitSHA        string                          // GitSHA of the application when compiled
+	Registry      prometheus.Registerer           // The Prometheus Registry to use. If nil, the global registry is used by default.
+	CancelSignals []os.Signal                     // OS Signals to be used to cancel running servers. Defaults to SIGINT/`os.Interrupt`.
+	PreStart      func(ctx context.Context) error // A function to be called before starting the service
+	PostShutdown  func(ctx context.Context) error // A function to be called before stopping the service
 }
 
 // RegisterFlags registers Service flags with pflags

--- a/service/example_test.go
+++ b/service/example_test.go
@@ -15,6 +15,7 @@
 package service_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -59,7 +60,7 @@ func Example() {
 
 	// Using the config, create the cobra command by passing in an HTTP and GRPC registration
 	// callback function
-	_ = config.ServerCmd("", "", func(c service.Config) service.HTTPService {
+	_ = config.ServerCmd(context.Background(), "", "", func(c service.Config) service.HTTPService {
 		return handler{environment: c.Environment}
 	}, func(c service.Config) service.GRPCService {
 		return handler{environment: c.Environment}

--- a/service/service.go
+++ b/service/service.go
@@ -157,7 +157,9 @@ func (c Config) ServerCmd(
 			}
 
 			if c.PreStart != nil {
-				if err := c.PreStart(ctx); err != nil {
+				var err error
+				ctx, err = c.PreStart(ctx)
+				if err != nil {
 					return err
 				}
 			}

--- a/service/service.go
+++ b/service/service.go
@@ -32,7 +32,6 @@ import (
 	"github.com/spothero/tools/log"
 	"github.com/spothero/tools/sentry"
 	"github.com/spothero/tools/tracing"
-	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 )
@@ -59,14 +58,13 @@ type GRPCService interface {
 //
 // Note that Version and GitSHA *must be specified* before calling this function.
 func (c Config) ServerCmd(
+	ctx context.Context,
 	shortDescription, longDescription string,
 	newHTTPService func(Config) HTTPService,
 	newGRPCService func(Config) GRPCService,
 ) *cobra.Command {
 	// HTTP Config
 	httpConfig := shHTTP.NewDefaultConfig(c.Name)
-	httpConfig.PreStart = c.PreStartHTTP
-	httpConfig.PostShutdown = c.PostShutdownHTTP
 	httpConfig.Middleware = []mux.MiddlewareFunc{
 		tracing.HTTPMiddleware,
 		shHTTP.NewMetrics(c.Registry, true).Middleware,
@@ -120,7 +118,7 @@ func (c Config) ServerCmd(
 			closer := tc.ConfigureTracer()
 			defer closer.Close()
 
-			// Ensure that GRPC Interceptors capture histograms
+			// Ensure that gRPC Interceptors capture histograms
 			grpcprom.EnableHandlingTimeHistogram()
 			grpcConfig.UnaryInterceptors = []grpc.UnaryServerInterceptor{
 				grpcot.UnaryServerInterceptor(),
@@ -157,26 +155,41 @@ func (c Config) ServerCmd(
 					jose.GetHTTPMiddleware(jh, jc.AuthRequired),
 				)
 			}
+
+			if c.PreStart != nil {
+				if err := c.PreStart(ctx); err != nil {
+					return err
+				}
+			}
+
 			var wg sync.WaitGroup
 			if newGRPCService != nil {
+				grpcDone, err := grpcConfig.NewServer().Run()
+				if err != nil {
+					return err
+				}
 				wg.Add(1)
 				go func() {
-					defer wg.Done()
-					if err := grpcConfig.NewServer().Run(); err != nil {
-						log.Get(context.Background()).Error("failed to run the grpc server", zap.Error(err))
-					}
+					<-grpcDone
+					wg.Done()
 				}()
 			}
-			if newHTTPService != nil {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if newHTTPService != nil {
 					httpService := newHTTPService(c)
 					httpConfig.RegisterHandlers = httpService.RegisterHandlers
-					httpConfig.NewServer().Run()
-				}()
-			}
+				}
+				httpConfig.NewServer().Run()
+			}()
+
 			wg.Wait()
+			if c.PostShutdown != nil {
+				if err := c.PostShutdown(ctx); err != nil {
+					return err
+				}
+			}
 			return nil
 		},
 	}


### PR DESCRIPTION
This PR adds pre-start and post-shutdown functions into to the `service` package and changes the gRPC server startup behavior.

* Pre-start and post-shutdown functions now exist at the service-level take a `context.Context`, enabling state passing between those two functions.
* gRPC `Run` is now non-blocking; instead, if the server can't startup, it will return an error immediately. If it can, it returns a channel that gets closed when it exits.
* The HTTP server now starts with metrics and health check endpoints, even if the user hasn't specified an HTTP server handler.
* I can't 100% confirm it, but I believe I fixed hanging tests.