### PR TITLE
Unifies MySQL and Postgres connection options & allows wrap overrides

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,7 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
+github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223 h1:F9x/1yl3T2AeKLr2AMdilSD8+f9bvMnNN8VS5iDtovc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nats-io/nats.go v1.8.1/go.mod h1:BrFz9vVn0fU3AcH9Vn4Kd7W0NpJ651tD5omQ3M8LwxM=
 github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7TDb/4=

--- a/sql/cli.go
+++ b/sql/cli.go
@@ -30,7 +30,6 @@ func (pc *PostgresConfig) RegisterFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&pc.SSLCert, "pg-ssl-cert", pc.SSLCert, "Path of the Postgres SSL Certificate on disk")
 	flags.StringVar(&pc.SSLKey, "pg-ssl-key", pc.SSLKey, "Path of the Postgres SSL Key on disk")
 	flags.StringVar(&pc.SSLRootCert, "pg-ssl-root-cert", pc.SSLRootCert, "Path of the Postgres SSL Root Cert on disk")
-	flags.DurationVar(&pc.MetricsFrequency, "pg-metrics-frequency", pc.MetricsFrequency, "Postgres metrics export frequency")
 }
 
 // RegisterFlags registers MySQL flags with pflags

--- a/sql/cli_test.go
+++ b/sql/cli_test.go
@@ -69,11 +69,6 @@ func TestPostgresConfigRegisterFlags(t *testing.T) {
 	sslRootCert, err := flags.GetString("pg-ssl-root-cert")
 	assert.NoError(t, err)
 	assert.Equal(t, "", sslRootCert)
-
-	mf, err := flags.GetDuration("pg-metrics-frequency")
-	assert.NoError(t, err)
-	assert.Equal(t, 0*time.Second, mf)
-
 }
 
 func TestMySQLConfig_RegisterFlags(t *testing.T) {

--- a/sql/postgres_test.go
+++ b/sql/postgres_test.go
@@ -26,12 +26,11 @@ func TestNewDefaultPostgresConfig(t *testing.T) {
 		t,
 		NewDefaultPostgresConfig("test", "testdb"),
 		PostgresConfig{
-			ApplicationName:  "test",
-			Host:             "localhost",
-			Port:             5432,
-			Database:         "testdb",
-			ConnectTimeout:   5 * time.Second,
-			MetricsFrequency: 5 * time.Second,
+			ApplicationName: "test",
+			Host:            "localhost",
+			Port:            5432,
+			Database:        "testdb",
+			ConnectTimeout:  5 * time.Second,
 		},
 	)
 }
@@ -113,18 +112,4 @@ func TestPostgresConfigBuildConnectionString(t *testing.T) {
 			assert.Equal(t, test.expectedURL, url)
 		})
 	}
-}
-
-func TestInstrumentPostgres(t *testing.T) {
-	pc := PostgresConfig{}
-	assert.False(t, pgWrapped)
-	err := pc.instrumentPostgres()
-	assert.NoError(t, err)
-	assert.True(t, pgWrapped)
-	err = pc.instrumentPostgres()
-	assert.Error(t, err)
-}
-
-func TestPostgresConfigConnect(t *testing.T) {
-
 }

--- a/sql/sql.go
+++ b/sql/sql.go
@@ -14,8 +14,77 @@
 
 package sql
 
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spothero/tools/log"
+	"github.com/spothero/tools/sql/middleware"
+	"github.com/spothero/tools/tracing"
+)
+
 // DBConnector is the interface which various Database-specific configuration objects must satisfy
 // to return a usable database connection to the caller
 type DBConnector interface {
 	Connect() error
+}
+
+type wrappedSQLOptions struct {
+	middleware                 middleware.Middleware
+	registerer                 prometheus.Registerer
+	mustRegister               bool
+	metricsCollectionFrequency time.Duration
+	driverName                 string
+}
+
+func newDefaultWrappedSQLOptions(driverName string) wrappedSQLOptions {
+	return wrappedSQLOptions{
+		middleware:                 middleware.Middleware{log.SQLMiddleware, tracing.SQLMiddleware},
+		registerer:                 prometheus.DefaultRegisterer,
+		mustRegister:               true,
+		metricsCollectionFrequency: 5 * time.Second,
+		driverName:                 driverName,
+	}
+}
+
+// WrappedSQLOption is a function that adds configuration for wrapping both
+// PostgreSQL and MySQL drivers.
+type WrappedSQLOption func(*wrappedSQLOptions)
+
+// WithMiddleware adds the provided middleware to the wrapped SQL options. Defaults to log and tracing middleware.
+func WithMiddleware(m middleware.Middleware) func(*wrappedSQLOptions) {
+	return func(config *wrappedSQLOptions) {
+		config.middleware = m
+	}
+}
+
+// WithMiddleware sets the Prometheus registerer to the wrapped SQL options. Defaults to the prometheus default
+// registerer.
+func WithMetricsRegisterer(r prometheus.Registerer) func(*wrappedSQLOptions) {
+	return func(config *wrappedSQLOptions) {
+		config.registerer = r
+	}
+}
+
+// WithMustRegister sets whether or not metrics must register in Prometheus. Defaults to true.
+func WithMustRegister(r bool) func(*wrappedSQLOptions) {
+	return func(config *wrappedSQLOptions) {
+		config.mustRegister = r
+	}
+}
+
+// WithMetricsCollectionFrequency sets the frequency at which database metrics will be collected
+// and made available in the Prometheus registry. Defaults to 5 seconds.
+func WithMetricsCollectionFrequency(f time.Duration) func(*wrappedSQLOptions) {
+	return func(config *wrappedSQLOptions) {
+		config.metricsCollectionFrequency = f
+	}
+}
+
+// WithDriverName overrides the default wrapped driver name so that multiple wrapped
+// drivers can be registered at once.
+func WithDriverName(n string) func(*wrappedSQLOptions) {
+	return func(config *wrappedSQLOptions) {
+		config.driverName = n
+	}
 }

--- a/sql/sql_test.go
+++ b/sql/sql_test.go
@@ -1,0 +1,65 @@
+package sql
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spothero/tools/log"
+	"github.com/spothero/tools/sql/middleware"
+	"github.com/spothero/tools/tracing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDefaultWrappedSQLOptions(t *testing.T) {
+	expected := wrappedSQLOptions{
+		middleware:                 middleware.Middleware{log.SQLMiddleware, tracing.SQLMiddleware},
+		registerer:                 prometheus.DefaultRegisterer,
+		mustRegister:               true,
+		metricsCollectionFrequency: 5 * time.Second,
+		driverName:                 "driver",
+	}
+	actual := newDefaultWrappedSQLOptions("driver")
+	assert.Equal(t, len(expected.middleware), len(actual.middleware))
+	assert.Equal(t, expected.registerer, actual.registerer)
+	assert.Equal(t, expected.mustRegister, actual.mustRegister)
+	assert.Equal(t, expected.metricsCollectionFrequency, actual.metricsCollectionFrequency)
+	assert.Equal(t, expected.driverName, actual.driverName)
+}
+
+func TestWrappedSQLConfigOptions(t *testing.T) {
+	tests := []struct {
+		name            string
+		option          WrappedSQLOption
+		expectedOptions wrappedSQLOptions
+	}{
+		{
+			"middleware",
+			WithMiddleware(middleware.Middleware{}),
+			wrappedSQLOptions{middleware: middleware.Middleware{}},
+		}, {
+			"registerer",
+			WithMetricsRegisterer(prometheus.DefaultRegisterer),
+			wrappedSQLOptions{registerer: prometheus.DefaultRegisterer},
+		}, {
+			"must register",
+			WithMustRegister(true),
+			wrappedSQLOptions{mustRegister: true},
+		}, {
+			"metrics collection frequency",
+			WithMetricsCollectionFrequency(time.Second),
+			wrappedSQLOptions{metricsCollectionFrequency: time.Second},
+		}, {
+			"driver name",
+			WithDriverName("driver"),
+			wrappedSQLOptions{driverName: "driver"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			opts := wrappedSQLOptions{}
+			test.option(&opts)
+			assert.Equal(t, test.expectedOptions, opts)
+		})
+	}
+}


### PR DESCRIPTION
My main motivation for this PR was to allow overriding the registered name of the wrapped driver. Instead of taking on another parameter to the constructor(s), I added functional options with nice defaults. Also, I unified the way that Postgres and MySQL connection API.

An example of how this can be used if you wanted to override the metrics collection frequency and driver name:

```go
cfg := sql.MySQLConfig{
    // connection options in here //
 }
conn, dbClose, err, := cfg.Connect(
    context.Background(), 
    sql.WithMetricsCollectionFrequency(10 * time.Second), 
    sql.WithDriverName("override-driver"))
```