### PR TITLE
Feature/http client

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -8,30 +8,36 @@ import (
 // ClientMiddleware defines an HTTP Client middleware function. The function is called prior to
 // invoking the transport roundtrip, and the returned response function is called after the
 // response has been received from the client.
-type ClientMiddleware func(*http.Request) (func(*http.Response) error, error)
+type ClientMiddleware func(*http.Request) (*http.Request, func(*http.Response) error, error)
 
 // MiddlewareRoundTripper implements a proxied net/http RoundTripper so that http requests may be decorated
 // with middleware
 type MiddlewareRoundTripper struct {
-	roundTripper http.RoundTripper
+	RoundTripper http.RoundTripper
 	Middleware   []ClientMiddleware
 }
 
 // RoundTrip completes the http request round trip and is responsible for invoking HTTP Client
 // Middleware
 func (mrt MiddlewareRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Ensure the RoundTripper was set on the MiddlewareRoundTripper
+	if mrt.RoundTripper == nil {
+		return nil, fmt.Errorf("no roundtripper provided to middleware round tripper")
+	}
+
 	// Call all middleware
 	responseHandlers := make([]func(*http.Response) error, len(mrt.Middleware))
 	for idx, middleware := range mrt.Middleware {
-		callback, err := middleware(req)
+		updatedReq, callback, err := middleware(req)
 		if err != nil {
 			return nil, fmt.Errorf("error invoking http client middleware: %w", err)
 		}
 		responseHandlers[idx] = callback
+		req = updatedReq
 	}
 
 	// Make the request
-	resp, err := mrt.roundTripper.RoundTrip(req)
+	resp, err := mrt.RoundTripper.RoundTrip(req)
 	if err != nil {
 		return nil, fmt.Errorf("http client request failed: %w", err)
 	}

--- a/http/client.go
+++ b/http/client.go
@@ -1,0 +1,55 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// ClientMiddleware defines an HTTP Client middleware function. The function is called prior to
+// invoking the transport roundtrip, and the returned response function is called after the
+// response has been received from the client.
+type ClientMiddleware func(*http.Request) (func(*http.Response) error, error)
+
+// MiddlewareRoundTripper implements a proxied net/http RoundTripper so that http requests may be decorated
+// with middleware
+type MiddlewareRoundTripper struct {
+	roundTripper http.RoundTripper
+	Middleware   []ClientMiddleware
+}
+
+// RoundTrip completes the http request round trip and is responsible for invoking HTTP Client
+// Middleware
+func (mrt MiddlewareRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Call all middleware
+	responseHandlers := make([]func(*http.Response) error, len(mrt.Middleware))
+	for idx, middleware := range mrt.Middleware {
+		callback, err := middleware(req)
+		if err != nil {
+			return nil, fmt.Errorf("error invoking http client middleware: %w", err)
+		}
+		responseHandlers[idx] = callback
+	}
+
+	// Make the request
+	resp, err := mrt.roundTripper.RoundTrip(req)
+	if err != nil {
+		return nil, fmt.Errorf("http client request failed: %w", err)
+	}
+
+	// Call response handler callbacks with the response
+	for _, callback := range responseHandlers {
+		if err := callback(resp); err != nil {
+			return nil, fmt.Errorf("error invoking http client response handler middleware: %w", err)
+		}
+	}
+	return resp, err
+}
+
+// BackoffClientMiddleware is middleware for use in HTTP Clients for automatically performing
+// exponential backoff and retries on failed HTTP requests
+func BackoffClientMiddleware(r *http.Request) (func(*http.Response) error, error) {
+	// TODO: Middleware!
+	return func(resp *http.Response) error {
+		return nil
+	}, nil
+}

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -1,0 +1,1 @@
+package http

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,6 +21,15 @@ func (mockRT MockRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 		return nil, fmt.Errorf("error in roundtripper")
 	}
 	return &http.Response{StatusCode: mockRT.responseStatusCode}, nil
+}
+
+func TestNewDefaultClient(t *testing.T) {
+	client := NewDefaultClient(NewMetrics(prometheus.NewRegistry(), true), nil)
+	assert.NotNil(t, client)
+	mrt, ok := client.Transport.(MiddlewareRoundTripper)
+	assert.True(t, ok)
+	assert.Equal(t, 4, len(mrt.Middleware))
+	assert.Equal(t, http.DefaultTransport, mrt.RoundTripper)
 }
 
 func TestRoundTrip(t *testing.T) {

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -1,1 +1,107 @@
 package http
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// This roundtripper is embedded within the MiddlewareRoundTripper as a noop
+type MockRoundTripper struct {
+	responseStatusCode int
+	createErr          bool
+}
+
+func (mockRT MockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if mockRT.createErr {
+		return nil, fmt.Errorf("error in roundtripper")
+	}
+	return &http.Response{StatusCode: mockRT.responseStatusCode}, nil
+}
+
+func TestRoundTrip(t *testing.T) {
+	tests := []struct {
+		name           string
+		roundTripper   http.RoundTripper
+		middlewareErr  bool
+		respHandlerErr bool
+		expectErr      bool
+	}{
+		{
+			"no round tripper results in an error",
+			nil,
+			false,
+			false,
+			true,
+		},
+		{
+			"round tripper with no error invokes middleware correctly",
+			MockRoundTripper{200, false},
+			false,
+			false,
+			false,
+		},
+		{
+			"round tripper with middleware error returns an error",
+			MockRoundTripper{200, false},
+			true,
+			false,
+			true,
+		},
+		{
+			"round tripper with internal roundtripper error returns an error",
+			MockRoundTripper{200, true},
+			false,
+			false,
+			true,
+		},
+		{
+			"round tripper with resp handler error returns an error",
+			MockRoundTripper{200, false},
+			false,
+			true,
+			true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			middlewareCalled := false
+			respHandlerCalled := false
+			mockMiddleware := func(req *http.Request) (*http.Request, func(*http.Response) error, error) {
+				middlewareCalled = true
+				var mwErr error
+				if test.middlewareErr {
+					mwErr = fmt.Errorf("middleware error")
+				}
+				return req,
+					func(*http.Response) error {
+						respHandlerCalled = true
+						var rhErr error
+						if test.respHandlerErr {
+							rhErr = fmt.Errorf("response handler error")
+						}
+						return rhErr
+					}, mwErr
+			}
+			mrt := MiddlewareRoundTripper{
+				RoundTripper: test.roundTripper,
+				Middleware: []ClientMiddleware{
+					mockMiddleware,
+				},
+			}
+			mockReq := httptest.NewRequest("GET", "/path", nil)
+			resp, err := mrt.RoundTrip(mockReq)
+			if test.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+				assert.True(t, middlewareCalled)
+				assert.True(t, respHandlerCalled)
+			}
+		})
+	}
+}

--- a/http/metrics.go
+++ b/http/metrics.go
@@ -77,8 +77,8 @@ func NewMetrics(registry prometheus.Registerer, mustRegister bool) Metrics {
 	contentLength := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "http_content_length_bytes",
-			Help: "HTTP Request content length histogram",
-			// Power of 2 bytes, starts at 1 byte and works up to 10MB
+			Help: "HTTP Request content length histogram, buckets range from 1B to 16MB",
+			// Power of 2 bytes, starts at 1 byte and works up to 16MB
 			Buckets: prometheus.ExponentialBuckets(1, 2.0, 24),
 		},
 		labels,
@@ -86,8 +86,8 @@ func NewMetrics(registry prometheus.Registerer, mustRegister bool) Metrics {
 	clientContentLength := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "http_client_content_length_bytes",
-			Help: "HTTP Client Request content length histogram",
-			// Power of 2 bytes, starts at 1 byte and works up to 10MB
+			Help: "HTTP Client Request content length histogram, buckets range from 1B to 16MB",
+			// Power of 2 bytes, starts at 1 byte and works up to 16MB
 			Buckets: prometheus.ExponentialBuckets(1, 2.0, 24),
 		},
 		labels,

--- a/http/metrics.go
+++ b/http/metrics.go
@@ -100,3 +100,11 @@ func (m Metrics) Middleware(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 }
+
+// MetricsClientMiddleware is middleware for use in HTTP Clients for capturing prometheus metrics
+func MetricsClientMiddleware(r *http.Request) (func(*http.Response) error, error) {
+	// TODO: Middleware!
+	return func(resp *http.Response) error {
+		return nil
+	}, nil
+}

--- a/http/metrics.go
+++ b/http/metrics.go
@@ -151,6 +151,11 @@ func (m Metrics) Middleware(next http.Handler) http.Handler {
 				labels["status_code"] = strconv.Itoa(statusRecorder.StatusCode)
 			}
 			m.counter.With(labels).Inc()
+			if contentLengthStr := r.Header.Get("Content-Length"); len(contentLengthStr) > 0 {
+				if contentLength, err := strconv.Atoi(contentLengthStr); err == nil {
+					m.contentLength.With(labels).Observe(float64(contentLength))
+				}
+			}
 			m.duration.With(labels).Observe(durationSec)
 		}))
 		defer timer.ObserveDuration()
@@ -167,6 +172,11 @@ func (m Metrics) ClientMiddleware(r *http.Request) (*http.Request, func(*http.Re
 			"status_code": strconv.Itoa(receivedResp.StatusCode),
 		}
 		m.clientCounter.With(labels).Inc()
+		if contentLengthStr := r.Header.Get("Content-Length"); len(contentLengthStr) > 0 {
+			if contentLength, err := strconv.Atoi(contentLengthStr); err == nil {
+				m.clientContentLength.With(labels).Observe(float64(contentLength))
+			}
+		}
 		m.clientDuration.With(labels).Observe(durationSec)
 	}
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(observerFunc))

--- a/http/metrics.go
+++ b/http/metrics.go
@@ -26,9 +26,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// BYTES_IN_MB defines the total number of bytes in a megabyte
-const BYTES_IN_MB = 100000
-
 // Metrics is a bundle of prometheus HTTP metrics recorders
 type Metrics struct {
 	counter             *prometheus.CounterVec
@@ -79,17 +76,19 @@ func NewMetrics(registry prometheus.Registerer, mustRegister bool) Metrics {
 	)
 	contentLength := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "http_content_length_bytes",
-			Help:    "HTTP Request content length histogram",
-			Buckets: prometheus.LinearBuckets(BYTES_IN_MB, BYTES_IN_MB, 10),
+			Name: "http_content_length_bytes",
+			Help: "HTTP Request content length histogram",
+			// Power of 2 bytes, starts at 1 byte and works up to 10MB
+			Buckets: prometheus.ExponentialBuckets(1, 2.0, 24),
 		},
 		labels,
 	)
 	clientContentLength := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "http_client_content_length_bytes",
-			Help:    "HTTP Client Request content length histogram",
-			Buckets: prometheus.LinearBuckets(BYTES_IN_MB, BYTES_IN_MB, 10),
+			Name: "http_client_content_length_bytes",
+			Help: "HTTP Client Request content length histogram",
+			// Power of 2 bytes, starts at 1 byte and works up to 10MB
+			Buckets: prometheus.ExponentialBuckets(1, 2.0, 24),
 		},
 		labels,
 	)

--- a/http/metrics.go
+++ b/http/metrics.go
@@ -27,8 +27,10 @@ import (
 
 // Metrics is a bundle of prometheus HTTP metrics recorders
 type Metrics struct {
-	counter  *prometheus.CounterVec
-	duration *prometheus.HistogramVec
+	counter        *prometheus.CounterVec
+	duration       *prometheus.HistogramVec
+	clientCounter  *prometheus.CounterVec
+	clientDuration *prometheus.HistogramVec
 }
 
 // NewMetrics creates and returns a metrics bundle. The user may optionally
@@ -40,6 +42,20 @@ func NewMetrics(registry prometheus.Registerer, mustRegister bool) Metrics {
 		prometheus.HistogramOpts{
 			Name: "http_request_duration_seconds",
 			Help: "Total duration histogram for the HTTP request",
+			// Power of 2 time - 1ms, 2ms, 4ms ... 32768ms, +Inf ms
+			Buckets: prometheus.ExponentialBuckets(0.001, 2.0, 16),
+		},
+		[]string{
+			// The path recording the request
+			"path",
+			// The Specific HTTP Status Code
+			"status_code",
+		},
+	)
+	clientHistogram := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "http_client_request_duration_seconds",
+			Help: "Total duration histogram for the HTTP client requests",
 			// Power of 2 time - 1ms, 2ms, 4ms ... 32768ms, +Inf ms
 			Buckets: prometheus.ExponentialBuckets(0.001, 2.0, 16),
 		},
@@ -62,24 +78,46 @@ func NewMetrics(registry prometheus.Registerer, mustRegister bool) Metrics {
 			"status_code",
 		},
 	)
+	clientCounter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "http_client_requests_total",
+			Help: "Total number of HTTP Client Requests sent",
+		},
+		[]string{
+			// The path recording the request
+			"path",
+			// The Specific HTTP Status Code
+			"status_code",
+		},
+	)
 	// If the user hasnt provided a Prometheus Registry, use the global Registry
 	if registry == nil {
 		registry = prometheus.DefaultRegisterer
 	}
 	if mustRegister {
 		registry.MustRegister(histogram)
+		registry.MustRegister(clientHistogram)
 		registry.MustRegister(counter)
+		registry.MustRegister(clientCounter)
 	} else {
 		if err := registry.Register(histogram); err != nil {
 			log.Get(context.Background()).Error("failed to register http histogram", zap.Error(err))
 		}
+		if err := registry.Register(clientHistogram); err != nil {
+			log.Get(context.Background()).Error("failed to register http client histogram", zap.Error(err))
+		}
 		if err := registry.Register(counter); err != nil {
 			log.Get(context.Background()).Error("failed to register http counter", zap.Error(err))
 		}
+		if err := registry.Register(clientCounter); err != nil {
+			log.Get(context.Background()).Error("failed to register http client counter", zap.Error(err))
+		}
 	}
 	return Metrics{
-		counter,
-		histogram,
+		counter:        counter,
+		clientCounter:  clientCounter,
+		duration:       histogram,
+		clientDuration: clientHistogram,
 	}
 }
 
@@ -101,10 +139,21 @@ func (m Metrics) Middleware(next http.Handler) http.Handler {
 	})
 }
 
-// MetricsClientMiddleware is middleware for use in HTTP Clients for capturing prometheus metrics
-func MetricsClientMiddleware(r *http.Request) (func(*http.Response) error, error) {
-	// TODO: Middleware!
-	return func(resp *http.Response) error {
+// ClientMiddleware is middleware for use in HTTP Clients for capturing prometheus metrics
+func (m Metrics) ClientMiddleware(r *http.Request) (*http.Request, func(*http.Response) error, error) {
+	var receivedResp *http.Response
+	observerFunc := func(durationSec float64) {
+		labels := prometheus.Labels{
+			"path":        r.URL.Path,
+			"status_code": strconv.Itoa(receivedResp.StatusCode),
+		}
+		m.clientCounter.With(labels).Inc()
+		m.clientDuration.With(labels).Observe(durationSec)
+	}
+	timer := prometheus.NewTimer(prometheus.ObserverFunc(observerFunc))
+	return r, func(resp *http.Response) error {
+		receivedResp = resp
+		timer.ObserveDuration()
 		return nil
 	}, nil
 }

--- a/http/metrics_test.go
+++ b/http/metrics_test.go
@@ -115,6 +115,10 @@ func TestMiddleware(t *testing.T) {
 	prometheus.Unregister(metrics.duration)
 	prometheus.Unregister(metrics.clientDuration)
 
+	// TODO: VERIFY CONTENTS
+	prometheus.Unregister(metrics.contentLength)
+	prometheus.Unregister(metrics.clientContentLength)
+
 	// Check request counter
 	counter, err := metrics.counter.GetMetricWith(labels)
 	assert.NoError(t, err)
@@ -159,6 +163,10 @@ func TestClientMiddleware(t *testing.T) {
 	}
 	prometheus.Unregister(metrics.duration)
 	prometheus.Unregister(metrics.clientDuration)
+
+	// TODO: VERIFY CONTENTS
+	prometheus.Unregister(metrics.contentLength)
+	prometheus.Unregister(metrics.clientContentLength)
 
 	// Check request counter
 	counter, err := metrics.clientCounter.GetMetricWith(labels)

--- a/http/metrics_test.go
+++ b/http/metrics_test.go
@@ -69,6 +69,8 @@ func TestNewMetrics(t *testing.T) {
 			assert.NotNil(t, metrics.clientCounter)
 			assert.NotNil(t, metrics.duration)
 			assert.NotNil(t, metrics.clientDuration)
+			assert.NotNil(t, metrics.contentLength)
+			assert.NotNil(t, metrics.clientContentLength)
 		})
 	}
 }
@@ -115,7 +117,13 @@ func TestMiddleware(t *testing.T) {
 	prometheus.Unregister(metrics.duration)
 	prometheus.Unregister(metrics.clientDuration)
 
-	// TODO: VERIFY CONTENTS
+	// Check content-length histogram
+	contentLengthHistogram, err := metrics.contentLength.GetMetricWith(labels)
+	assert.NoError(t, err)
+	pb = &dto.Metric{}
+	assert.NoError(t, contentLengthHistogram.(prometheus.Histogram).Write(pb))
+	buckets = pb.Histogram.GetBucket()
+	assert.NotEmpty(t, buckets)
 	prometheus.Unregister(metrics.contentLength)
 	prometheus.Unregister(metrics.clientContentLength)
 
@@ -164,7 +172,13 @@ func TestClientMiddleware(t *testing.T) {
 	prometheus.Unregister(metrics.duration)
 	prometheus.Unregister(metrics.clientDuration)
 
-	// TODO: VERIFY CONTENTS
+	// Check content-length histogram
+	contentLengthHistogram, err := metrics.clientContentLength.GetMetricWith(labels)
+	assert.NoError(t, err)
+	pb = &dto.Metric{}
+	assert.NoError(t, contentLengthHistogram.(prometheus.Histogram).Write(pb))
+	buckets = pb.Histogram.GetBucket()
+	assert.NotEmpty(t, buckets)
 	prometheus.Unregister(metrics.contentLength)
 	prometheus.Unregister(metrics.clientContentLength)
 

--- a/jose/middleware.go
+++ b/jose/middleware.go
@@ -16,6 +16,7 @@ package jose
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -95,9 +96,9 @@ func GetHTTPMiddleware(jh JOSEHandler, authRequired bool) func(next http.Handler
 
 // HTTPClientMiddleware is middleware for use in HTTP Clients which propagates the Authorization
 // headers
-func HTTPClientMiddleware(r *http.Request) (func(*http.Response) error, error) {
-	// TODO: Middleware!
-	return func(resp *http.Response) error {
-		return nil
-	}, nil
+func HTTPClientMiddleware(r *http.Request) (*http.Request, func(*http.Response) error, error) {
+	if jwtData, ok := r.Context().Value(JWTClaimKey).(string); ok {
+		r.Header.Set(authHeader, fmt.Sprintf("%s%s", bearerPrefix, jwtData))
+	}
+	return r, func(resp *http.Response) error { return nil }, nil
 }

--- a/jose/middleware.go
+++ b/jose/middleware.go
@@ -37,11 +37,11 @@ const (
 	noBearerToken        = "no authorization bearer token found"
 )
 
-// GetHTTPMiddleware returns an HTTP middleware function which extracts the Authorization header,
-// if present, on all incoming HTTP requests. If an Authorization header is found, this middleware
-// attempts to parse and validate that value as a JWT with the configured Credential types for
-// the given JOSE provider.
-func GetHTTPMiddleware(jh JOSEHandler, authRequired bool) func(next http.Handler) http.Handler {
+// GetHTTPServerMiddleware returns an HTTP middleware function which extracts the Authorization
+// header, if present, on all incoming HTTP requests. If an Authorization header is found, this
+// middleware attempts to parse and validate that value as a JWT with the configured Credential
+// types for the given JOSE provider.
+func GetHTTPServerMiddleware(jh JOSEHandler, authRequired bool) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			logger := log.Get(r.Context())

--- a/jose/middleware.go
+++ b/jose/middleware.go
@@ -92,3 +92,12 @@ func GetHTTPMiddleware(jh JOSEHandler, authRequired bool) func(next http.Handler
 		})
 	}
 }
+
+// HTTPClientMiddleware is middleware for use in HTTP Clients which propagates the Authorization
+// headers
+func HTTPClientMiddleware(r *http.Request) (func(*http.Response) error, error) {
+	// TODO: Middleware!
+	return func(resp *http.Response) error {
+		return nil
+	}, nil
+}

--- a/jose/middleware_test.go
+++ b/jose/middleware_test.go
@@ -15,6 +15,7 @@
 package jose
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -181,4 +182,15 @@ func TestGetHTTPMiddleware(t *testing.T) {
 			assert.Equal(t, test.expectNextHandlerCalled, testHandlerCalled)
 		})
 	}
+}
+
+func TestHTTPClientMiddleware(t *testing.T) {
+	mockReq := httptest.NewRequest("GET", "/path", nil)
+	mockReq = mockReq.WithContext(context.WithValue(mockReq.Context(), JWTClaimKey, "jwt"))
+	req, respHandler, err := HTTPClientMiddleware(mockReq)
+	assert.NoError(t, err)
+	assert.NotNil(t, respHandler)
+	assert.NotNil(t, req)
+	assert.NoError(t, respHandler(&http.Response{}))
+	assert.Equal(t, mockReq.Header.Get(authHeader), fmt.Sprintf("%s%s", bearerPrefix, "jwt"))
 }

--- a/jose/middleware_test.go
+++ b/jose/middleware_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetHTTPMiddleware(t *testing.T) {
+func TestGetHTTPServerMiddleware(t *testing.T) {
 	tests := []struct {
 		name                    string
 		authHeaderPresent       bool
@@ -157,7 +157,7 @@ func TestGetHTTPMiddleware(t *testing.T) {
 				}
 			})
 
-			joseMiddleware := GetHTTPMiddleware(handler, test.authRequired)
+			joseMiddleware := GetHTTPServerMiddleware(handler, test.authRequired)
 			testServer := httptest.NewServer(joseMiddleware(testHandler))
 			defer testServer.Close()
 

--- a/log/middleware.go
+++ b/log/middleware.go
@@ -66,7 +66,7 @@ func HTTPMiddleware(next http.Handler) http.Handler {
 }
 
 // HTTPClientMiddleware is middleware for use in HTTP Clients which logs outbound requests
-func HTTPClientMiddleware(r *http.Request) (func(*http.Response) error, error) {
+func HTTPClientMiddleware(r *http.Request) (*http.Request, func(*http.Response) error, error) {
 	startTime := time.Now()
 	requestLogger := Get(r.Context())
 	logger := requestLogger.Named("http")
@@ -74,7 +74,7 @@ func HTTPClientMiddleware(r *http.Request) (func(*http.Response) error, error) {
 	path := zap.String("http.path", writer.FetchRoutePathTemplate(r))
 	query := zap.String("http.query", r.URL.Query().Encode())
 	logger.Debug("http request started", method, path, query)
-	return func(resp *http.Response) error {
+	return r, func(resp *http.Response) error {
 		logger.Info(
 			"http request completed",
 			zap.Int("http.status_code", resp.StatusCode),

--- a/log/middleware_test.go
+++ b/log/middleware_test.go
@@ -27,7 +27,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func TestHTTPMiddleware(t *testing.T) {
+func TestHTTPServerMiddleware(t *testing.T) {
 	recordedLogs := makeLoggerObservable(t, zapcore.DebugLevel)
 
 	// setup a test server with logging middleware and a handler that sets the status code
@@ -36,7 +36,7 @@ func TestHTTPMiddleware(t *testing.T) {
 		w.WriteHeader(statusCode)
 		verifyLogContext(t, r.Context())
 	})
-	testServer := httptest.NewServer(writer.StatusRecorderMiddleware(HTTPMiddleware(testHandler)))
+	testServer := httptest.NewServer(writer.StatusRecorderMiddleware(HTTPServerMiddleware(testHandler)))
 	defer testServer.Close()
 	res, err := http.Get(testServer.URL)
 	require.NoError(t, err)
@@ -50,14 +50,14 @@ func TestHTTPMiddleware(t *testing.T) {
 	for idx, field := range currLogs[0].Context {
 		foundLogKeysRequest[idx] = field.Key
 	}
-	assert.ElementsMatch(t, []string{"http.method", "http.url", "http.path", "http.user_agent"}, foundLogKeysRequest)
+	assert.ElementsMatch(t, []string{"http.method", "http.url", "http.path", "http.user_agent", "http.content_length"}, foundLogKeysRequest)
 
 	// Test that response parameters are appropriately logged to our standards
 	foundLogKeysResponse := make([]string, len(currLogs[1].Context))
 	for idx, field := range currLogs[1].Context {
 		foundLogKeysResponse[idx] = field.Key
 	}
-	assert.ElementsMatch(t, []string{"http.url", "http.method", "http.path", "http.status_code", "http.duration", "http.user_agent"}, foundLogKeysResponse)
+	assert.ElementsMatch(t, []string{"http.url", "http.method", "http.path", "http.status_code", "http.duration", "http.user_agent", "http.content_length"}, foundLogKeysResponse)
 	assert.Equal(t, currLogs[1].Context[0].Integer, int64(statusCode))
 }
 
@@ -80,14 +80,14 @@ func TestHTTPClientMiddleware(t *testing.T) {
 	for idx, field := range currLogs[0].Context {
 		foundLogKeysRequest[idx] = field.Key
 	}
-	assert.ElementsMatch(t, []string{"http.method", "http.url", "http.path", "http.user_agent"}, foundLogKeysRequest)
+	assert.ElementsMatch(t, []string{"http.method", "http.url", "http.path", "http.user_agent", "http.content_length"}, foundLogKeysRequest)
 
 	// Test that response parameters are appropriately logged to our standards
 	foundLogKeysResponse := make([]string, len(currLogs[1].Context))
 	for idx, field := range currLogs[1].Context {
 		foundLogKeysResponse[idx] = field.Key
 	}
-	assert.ElementsMatch(t, []string{"http.url", "http.path", "http.method", "http.status_code", "http.user_agent", "http.duration"}, foundLogKeysResponse)
+	assert.ElementsMatch(t, []string{"http.url", "http.path", "http.method", "http.status_code", "http.user_agent", "http.duration", "http.content_length"}, foundLogKeysResponse)
 	assert.Equal(t, currLogs[1].Context[0].Integer, int64(http.StatusOK))
 }
 

--- a/log/middleware_test.go
+++ b/log/middleware_test.go
@@ -50,14 +50,14 @@ func TestHTTPMiddleware(t *testing.T) {
 	for idx, field := range currLogs[0].Context {
 		foundLogKeysRequest[idx] = field.Key
 	}
-	assert.ElementsMatch(t, []string{"http.method", "http.path", "http.query"}, foundLogKeysRequest)
+	assert.ElementsMatch(t, []string{"http.method", "http.url", "http.path", "http.user_agent"}, foundLogKeysRequest)
 
 	// Test that response parameters are appropriately logged to our standards
 	foundLogKeysResponse := make([]string, len(currLogs[1].Context))
 	for idx, field := range currLogs[1].Context {
 		foundLogKeysResponse[idx] = field.Key
 	}
-	assert.ElementsMatch(t, []string{"http.path", "http.method", "http.status_code", "http.duration"}, foundLogKeysResponse)
+	assert.ElementsMatch(t, []string{"http.url", "http.method", "http.path", "http.status_code", "http.duration", "http.user_agent"}, foundLogKeysResponse)
 	assert.Equal(t, currLogs[1].Context[0].Integer, int64(statusCode))
 }
 
@@ -80,14 +80,14 @@ func TestHTTPClientMiddleware(t *testing.T) {
 	for idx, field := range currLogs[0].Context {
 		foundLogKeysRequest[idx] = field.Key
 	}
-	assert.ElementsMatch(t, []string{"http.method", "http.path", "http.query"}, foundLogKeysRequest)
+	assert.ElementsMatch(t, []string{"http.method", "http.url", "http.path", "http.user_agent"}, foundLogKeysRequest)
 
 	// Test that response parameters are appropriately logged to our standards
 	foundLogKeysResponse := make([]string, len(currLogs[1].Context))
 	for idx, field := range currLogs[1].Context {
 		foundLogKeysResponse[idx] = field.Key
 	}
-	assert.ElementsMatch(t, []string{"http.path", "http.method", "http.status_code", "http.duration"}, foundLogKeysResponse)
+	assert.ElementsMatch(t, []string{"http.url", "http.path", "http.method", "http.status_code", "http.user_agent", "http.duration"}, foundLogKeysResponse)
 	assert.Equal(t, currLogs[1].Context[0].Integer, int64(http.StatusOK))
 }
 

--- a/log/middleware_test.go
+++ b/log/middleware_test.go
@@ -65,9 +65,10 @@ func TestHTTPClientMiddleware(t *testing.T) {
 	recordedLogs := makeLoggerObservable(t, zapcore.DebugLevel)
 
 	mockReq := httptest.NewRequest("GET", "/path", nil)
-	mockReq, responseHandler, err := HTTPClientMiddleware(mockReq)
+	req, responseHandler, err := HTTPClientMiddleware(mockReq)
 	assert.NoError(t, err)
 	assert.NotNil(t, responseHandler)
+	assert.NotNil(t, req)
 
 	mockResp := &http.Response{StatusCode: http.StatusOK}
 	assert.NoError(t, responseHandler(mockResp))

--- a/log/middleware_test.go
+++ b/log/middleware_test.go
@@ -65,7 +65,7 @@ func TestHTTPClientMiddleware(t *testing.T) {
 	recordedLogs := makeLoggerObservable(t, zapcore.DebugLevel)
 
 	mockReq := httptest.NewRequest("GET", "/path", nil)
-	responseHandler, err := HTTPClientMiddleware(mockReq)
+	mockReq, responseHandler, err := HTTPClientMiddleware(mockReq)
 	assert.NoError(t, err)
 	assert.NotNil(t, responseHandler)
 

--- a/sentry/middleware_test.go
+++ b/sentry/middleware_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHTTPMiddleware(t *testing.T) {
+func TestHTTPServerMiddleware(t *testing.T) {
 	testHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		assert.True(t, sentry.HasHubOnContext(r.Context()))
 		hub := sentry.GetHubFromContext(r.Context())
@@ -22,7 +22,7 @@ func TestHTTPMiddleware(t *testing.T) {
 		assert.NotEqual(t, clone.Scope(), hub.Scope())
 	})
 
-	testServer := httptest.NewServer(tracing.HTTPMiddleware(NewMiddleware().HTTP(testHandler)))
+	testServer := httptest.NewServer(tracing.HTTPServerMiddleware(NewMiddleware().HTTP(testHandler)))
 	defer testServer.Close()
 	res, err := http.Get(testServer.URL)
 	require.NoError(t, err)

--- a/service/service.go
+++ b/service/service.go
@@ -67,9 +67,9 @@ func (c Config) ServerCmd(
 	// HTTP Config
 	httpConfig := shHTTP.NewDefaultConfig(c.Name)
 	httpConfig.Middleware = []mux.MiddlewareFunc{
-		tracing.HTTPMiddleware,
+		tracing.HTTPServerMiddleware,
 		shHTTP.NewMetrics(c.Registry, true).Middleware,
-		log.HTTPMiddleware,
+		log.HTTPServerMiddleware,
 		sentry.NewMiddleware().HTTP,
 	}
 
@@ -151,7 +151,7 @@ func (c Config) ServerCmd(
 				)
 				httpConfig.Middleware = append(
 					httpConfig.Middleware,
-					jose.GetHTTPMiddleware(jh, jc.AuthRequired),
+					jose.GetHTTPServerMiddleware(jh, jc.AuthRequired),
 				)
 			}
 

--- a/tracing/middleware.go
+++ b/tracing/middleware.go
@@ -53,6 +53,8 @@ func HTTPMiddleware(next http.Handler) http.Handler {
 		span, spanCtx := opentracing.StartSpanFromContext(r.Context(), writer.FetchRoutePathTemplate(r), ext.RPCServerOption(wireContext))
 		span = span.SetTag("http.method", r.Method)
 		span = span.SetTag("http.url", r.URL.String())
+		span = span.SetTag("http.path", writer.FetchRoutePathTemplate(r))
+		span = span.SetTag("http.user_agent", r.UserAgent())
 
 		defer func() {
 			if statusRecorder, ok := w.(*writer.StatusRecorder); ok {
@@ -74,6 +76,8 @@ func HTTPClientMiddleware(r *http.Request) (*http.Request, func(*http.Response) 
 	span, spanCtx := opentracing.StartSpanFromContext(r.Context(), operationName)
 	span = span.SetTag("http.method", r.Method)
 	span = span.SetTag("http.url", r.URL.String())
+	span = span.SetTag("http.path", writer.FetchRoutePathTemplate(r))
+	span = span.SetTag("http.user_agent", r.UserAgent())
 	return r.WithContext(EmbedCorrelationID(spanCtx)),
 		func(resp *http.Response) error {
 			span = span.SetTag("http.status_code", resp.Status)

--- a/tracing/middleware_test.go
+++ b/tracing/middleware_test.go
@@ -28,6 +28,20 @@ import (
 	jaeger "github.com/uber/jaeger-client-go"
 )
 
+func TestSetSpanTags(t *testing.T) {
+	tracer, closer := jaeger.NewTracer("t", jaeger.NewConstSampler(false), jaeger.NewInMemoryReporter())
+	defer closer.Close()
+	opentracing.SetGlobalTracer(tracer)
+	span, _ := opentracing.StartSpanFromContext(context.Background(), "test")
+
+	mockReq := httptest.NewRequest("POST", "/path", nil)
+	mockReq.Header.Set("Content-Length", "1")
+
+	// There's not much we can test here since we can't access the underlying tags
+	span = setSpanTags(mockReq, span)
+	assert.NotNil(t, span)
+}
+
 func TestHTTPServerMiddleware(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/tracing/middleware_test.go
+++ b/tracing/middleware_test.go
@@ -28,7 +28,7 @@ import (
 	jaeger "github.com/uber/jaeger-client-go"
 )
 
-func TestHTTPMiddleware(t *testing.T) {
+func TestHTTPServerMiddleware(t *testing.T) {
 	tests := []struct {
 		name              string
 		withExistingTrace bool
@@ -86,7 +86,7 @@ func TestHTTPMiddleware(t *testing.T) {
 			})
 
 			testServer := httptest.NewServer(
-				writer.StatusRecorderMiddleware(existingSpanMiddleware(HTTPMiddleware(testHandler))))
+				writer.StatusRecorderMiddleware(existingSpanMiddleware(HTTPServerMiddleware(testHandler))))
 			defer testServer.Close()
 			res, err := http.Get(testServer.URL)
 			require.NoError(t, err)
@@ -132,7 +132,7 @@ func TestHTTPClientMiddleware(t *testing.T) {
 }
 
 func TestGetCorrelationID(t *testing.T) {
-	// first, assert a request through the HTTPMiddleware contains a context
+	// first, assert a request through the HTTPServerMiddleware contains a context
 	// which produces a meaningful result for GetCorrelationID()
 	tracer, closer := jaeger.NewTracer("t", jaeger.NewConstSampler(false), jaeger.NewInMemoryReporter())
 	defer closer.Close()
@@ -151,7 +151,7 @@ func TestGetCorrelationID(t *testing.T) {
 		assert.Equal(t, correlationId, _correlationId)
 	})
 
-	testServer := httptest.NewServer(writer.StatusRecorderMiddleware(HTTPMiddleware(testHandler)))
+	testServer := httptest.NewServer(writer.StatusRecorderMiddleware(HTTPServerMiddleware(testHandler)))
 	defer testServer.Close()
 	res, err := http.Get(testServer.URL)
 	require.NoError(t, err)


### PR DESCRIPTION
Opening this up for feedback now. I'm not deeply satisfied with where this ended up. There are a couple of issues that need to be figured out.

First, the way that we create `http.Metrics` with `http.NewMetrics` will not work correctly with the default client. I need to step back and think of a more effective way of creating and sharing around that metrics bundle.

Second, I'm not happy at all with 

`func (mrt MiddlewareRoundTripper) RounTrip()...`

and the way it handles Middleware. I'm considering rewriting this to instead be a series of `http.RoundTripper` interfaces that nest eachother... But before I do that I want to get your perspective.

The reason I don't like this current approach is that it makes things like exponential backoff essentially impossible.