### PR TITLE
Feature/refactor http client middleware

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -78,7 +78,7 @@ func NewDefaultClient(metrics Metrics, roundTripper http.RoundTripper) http.Clie
 func (rrt RetryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Ensure the RoundTripper was set on the MiddlewareRoundTripper
 	if rrt.RoundTripper == nil {
-		panic("no roundtripper provided to middleware round tripper")
+		panic("no roundtripper provided to retry round tripper")
 	}
 
 	var resp *http.Response

--- a/http/client.go
+++ b/http/client.go
@@ -42,13 +42,11 @@ type RetryRoundTripper struct {
 // passthrough, and logging. Providing the base HTTP RoundTripper is optional.
 // If `nil` is received, the net/http DefaultClient will be used.
 //
-// By default, the client is provides exponential backoff on 500-504 errors. The default
+// By default, the client provides exponential backoff on 500-504 errors. The default
 // configuration for exponential backoff is to start with an interval of 100 milliseconds, a
-// multiplier of two, a randomization factor of 0.5 (for jitter), a max interval of 10 seconds,
-// and finally, the retry will attempt 5 times before failing if the error is retriable.
-//
-// In addition, the RoundTripper chain will instrument HTTP calls with prometheus metrics,
-// jaeger tracing, auth header passthrough, and zap logging.
+// multiplier of two, a randomization factor of up to 0.5 milliseconds (for jitter), a max
+// interval of 10 seconds, and finally, the retry will attempt 5 times before failing if the
+// error is retriable.
 func NewDefaultClient(metrics Metrics, roundTripper http.RoundTripper) http.Client {
 	if roundTripper == nil {
 		roundTripper = http.DefaultTransport
@@ -76,7 +74,7 @@ func NewDefaultClient(metrics Metrics, roundTripper http.RoundTripper) http.Clie
 
 // RoundTrip completes the http request round trip but attempts retries for configured error codes
 func (rrt RetryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Ensure the RoundTripper was set on the MiddlewareRoundTripper
+	// Ensure the RoundTripper was set on the RetryRoundTripper
 	if rrt.RoundTripper == nil {
 		panic("no roundtripper provided to retry round tripper")
 	}

--- a/http/client.go
+++ b/http/client.go
@@ -20,30 +20,11 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/spothero/tools/jose"
 	"github.com/spothero/tools/log"
+	"github.com/spothero/tools/tracing"
 	"go.uber.org/zap"
 )
-
-// ClientMiddleware defines an HTTP Client middleware function. The function is called prior to
-// invoking the transport roundtrip, and the returned response function is called after the
-// response has been received from the client.
-type ClientMiddleware func(*http.Request) (*http.Request, func(*http.Response) error, error)
-
-// MiddlewareRoundTripper implements a proxied net/http RoundTripper so that http requests may be decorated
-// with middleware
-type MiddlewareRoundTripper struct {
-	RoundTripper http.RoundTripper
-	// Middleware consist of a function which is called prior to the execution of a request. This
-	// function returns the potentially modified request, the post-response handler, and an error,
-	// if any. The response handler is invoked after the HTTP request has been made.
-	//
-	// Middleware are called in the order they are specified. In otherwords, the first item in the
-	// slice is the first middleware applied, and the last item in the slice is the last middleware
-	// applied. Each response handler is called in the reverse order of the middleware. Meaning,
-	// the last middleware called will be the first to have its response handler called, and
-	// likewise, the first middleware called will be the last to have its handler called.
-	Middleware []ClientMiddleware
-}
 
 // RetryRoundTripper wraps a roundtripper with retry logic
 type RetryRoundTripper struct {
@@ -56,15 +37,17 @@ type RetryRoundTripper struct {
 	MaxRetries           uint8
 }
 
-// NewDefaultClient constructs the default HTTP Client with middleware. Providing an HTTP
-// RoundTripper is optional. If `nil` is received, the DefaultClient will be used.
+// NewDefaultClient constructs the default HTTP Client with a series of HTTP RoundTrippers that
+// provide additional features, such as exponential backoff, metrics, tracing, authentication
+// passthrough, and logging. Providing the base HTTP RoundTripper is optional.
+// If `nil` is received, the net/http DefaultClient will be used.
 //
 // By default, the client is provides exponential backoff on 500-504 errors. The default
 // configuration for exponential backoff is to start with an interval of 100 milliseconds, a
 // multiplier of two, a randomization factor of 0.5 (for jitter), a max interval of 10 seconds,
 // and finally, the retry will attempt 5 times before failing if the error is retriable.
 //
-// In addition, the middleware included will instrument HTTP calls with prometheus metrics,
+// In addition, the RoundTripper chain will instrument HTTP calls with prometheus metrics,
 // jaeger tracing, auth header passthrough, and zap logging.
 func NewDefaultClient(metrics Metrics, roundTripper http.RoundTripper) http.Client {
 	if roundTripper == nil {
@@ -84,55 +67,11 @@ func NewDefaultClient(metrics Metrics, roundTripper http.RoundTripper) http.Clie
 		RandomizationFactor: 0.5,
 		MaxRetries:          5,
 	}
-	return http.Client{
-		Transport: MiddlewareRoundTripper{
-			Middleware: []ClientMiddleware{
-				//tracing.HTTPClientMiddleware,
-				//log.HTTPClientMiddleware,
-				//metrics.ClientMiddleware,
-				//jose.HTTPClientMiddleware,
-			},
-			RoundTripper: retryRoundTripper,
-		},
-	}
-}
-
-// RoundTrip completes the http request round trip and is responsible for invoking HTTP Client
-// Middleware
-func (mrt MiddlewareRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Ensure the RoundTripper was set on the MiddlewareRoundTripper
-	if mrt.RoundTripper == nil {
-		panic("no roundtripper provided to middleware round tripper")
-	}
-
-	// Call all middleware
-	numMiddleware := len(mrt.Middleware)
-	responseHandlers := make([]func(*http.Response) error, numMiddleware)
-	for idx, middleware := range mrt.Middleware {
-		updatedReq, callback, err := middleware(req)
-		if err != nil {
-			return nil, fmt.Errorf("error invoking http client middleware: %w", err)
-		}
-		// Append handlers in reverse order so that nesting is reverse on response handling.
-		// Always call the last middleware's response handler first, the second to last
-		// middleware's response handler second, and so on.
-		responseHandlers[numMiddleware-idx-1] = callback
-		req = updatedReq
-	}
-
-	// Make the request
-	resp, err := mrt.RoundTripper.RoundTrip(req)
-	if err != nil {
-		return nil, fmt.Errorf("http client request failed: %w", err)
-	}
-
-	// Call response handler callbacks with the response
-	for _, callback := range responseHandlers {
-		if err := callback(resp); err != nil {
-			return nil, fmt.Errorf("error invoking http client response handler middleware: %w", err)
-		}
-	}
-	return resp, err
+	tracingRoundTripper := tracing.RoundTripper{RoundTripper: retryRoundTripper}
+	loggingRoundTripper := log.RoundTripper{RoundTripper: tracingRoundTripper}
+	metricsRoundTripper := MetricsRoundTripper{RoundTripper: loggingRoundTripper}
+	joseRoundTripper := jose.RoundTripper{RoundTripper: metricsRoundTripper}
+	return http.Client{Transport: joseRoundTripper}
 }
 
 // RoundTrip completes the http request round trip but attempts retries for configured error codes

--- a/http/client.go
+++ b/http/client.go
@@ -77,7 +77,7 @@ func NewDefaultClient(metrics Metrics, roundTripper http.RoundTripper) http.Clie
 			Middleware: []ClientMiddleware{
 				tracing.HTTPClientMiddleware,
 				log.HTTPClientMiddleware,
-				metrics.ClientMiddleware,
+				//metrics.ClientMiddleware,
 				jose.HTTPClientMiddleware,
 			},
 			RoundTripper: retryRoundTripper,

--- a/http/client.go
+++ b/http/client.go
@@ -1,3 +1,17 @@
+// Copyright 2020 SpotHero
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package http
 
 import (
@@ -6,9 +20,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/spothero/tools/jose"
 	"github.com/spothero/tools/log"
-	"github.com/spothero/tools/tracing"
 	"go.uber.org/zap"
 )
 
@@ -75,10 +87,10 @@ func NewDefaultClient(metrics Metrics, roundTripper http.RoundTripper) http.Clie
 	return http.Client{
 		Transport: MiddlewareRoundTripper{
 			Middleware: []ClientMiddleware{
-				tracing.HTTPClientMiddleware,
-				log.HTTPClientMiddleware,
+				//tracing.HTTPClientMiddleware,
+				//log.HTTPClientMiddleware,
 				//metrics.ClientMiddleware,
-				jose.HTTPClientMiddleware,
+				//jose.HTTPClientMiddleware,
 			},
 			RoundTripper: retryRoundTripper,
 		},

--- a/http/client.go
+++ b/http/client.go
@@ -42,7 +42,7 @@ type RetryRoundTripper struct {
 // passthrough, and logging. Providing the base HTTP RoundTripper is optional.
 // If `nil` is received, the net/http DefaultClient will be used.
 //
-// By default, the client provides exponential backoff on 500-504 errors. The default
+// By default, the client provides exponential backoff on [500-504] errors. The default
 // configuration for exponential backoff is to start with an interval of 100 milliseconds, a
 // multiplier of two, a randomization factor of up to 0.5 milliseconds (for jitter), a max
 // interval of 10 seconds, and finally, the retry will attempt 5 times before failing if the

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -15,7 +15,6 @@
 package http
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -23,116 +22,30 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spothero/tools/http/roundtrip"
+	"github.com/spothero/tools/jose"
+	"github.com/spothero/tools/log"
+	"github.com/spothero/tools/tracing"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewDefaultClient(t *testing.T) {
 	client := NewDefaultClient(NewMetrics(prometheus.NewRegistry(), true), nil)
 	assert.NotNil(t, client)
-	mrt, ok := client.Transport.(MiddlewareRoundTripper)
+	jrt, ok := client.Transport.(jose.RoundTripper)
 	assert.True(t, ok)
-	// TODO: FIX THIS
-	//assert.Equal(t, 4, len(mrt.Middleware))
 
-	rrt, ok := mrt.RoundTripper.(RetryRoundTripper)
+	mrt, ok := jrt.RoundTripper.(MetricsRoundTripper)
+	assert.True(t, ok)
+
+	lrt, ok := mrt.RoundTripper.(log.RoundTripper)
+	assert.True(t, ok)
+
+	trt, ok := lrt.RoundTripper.(tracing.RoundTripper)
+	assert.True(t, ok)
+
+	rrt, ok := trt.RoundTripper.(RetryRoundTripper)
 	assert.True(t, ok)
 	assert.Equal(t, http.DefaultTransport, rrt.RoundTripper)
-}
-
-func TestMiddlewareRoundTrip(t *testing.T) {
-	tests := []struct {
-		name           string
-		roundTripper   http.RoundTripper
-		middlewareErr  bool
-		respHandlerErr bool
-		expectErr      bool
-		expectPanic    bool
-	}{
-		{
-			"no round tripper results in a panic",
-			nil,
-			false,
-			false,
-			false,
-			true,
-		},
-		{
-			"round tripper with no error invokes middleware correctly",
-			&roundtrip.MockRoundTripper{ResponseStatusCodes: []int{http.StatusOK}, CreateErr: false},
-			false,
-			false,
-			false,
-			false,
-		},
-		{
-			"round tripper with middleware error returns an error",
-			&roundtrip.MockRoundTripper{ResponseStatusCodes: []int{http.StatusOK}, CreateErr: false},
-			true,
-			false,
-			true,
-			false,
-		},
-		{
-			"round tripper with internal roundtripper error returns an error",
-			&roundtrip.MockRoundTripper{ResponseStatusCodes: []int{http.StatusOK}, CreateErr: true},
-			false,
-			false,
-			true,
-			false,
-		},
-		{
-			"round tripper with resp handler error returns an error",
-			&roundtrip.MockRoundTripper{ResponseStatusCodes: []int{http.StatusOK}, CreateErr: false},
-			false,
-			true,
-			true,
-			false,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			middlewareCalled := false
-			respHandlerCalled := false
-			mockMiddleware := func(req *http.Request) (*http.Request, func(*http.Response) error, error) {
-				middlewareCalled = true
-				var mwErr error
-				if test.middlewareErr {
-					mwErr = fmt.Errorf("middleware error")
-				}
-				return req,
-					func(*http.Response) error {
-						respHandlerCalled = true
-						var rhErr error
-						if test.respHandlerErr {
-							rhErr = fmt.Errorf("response handler error")
-						}
-						return rhErr
-					}, mwErr
-			}
-			mrt := MiddlewareRoundTripper{
-				RoundTripper: test.roundTripper,
-				Middleware: []ClientMiddleware{
-					mockMiddleware,
-				},
-			}
-			mockReq := httptest.NewRequest("GET", "/path", nil)
-			if !test.expectPanic {
-				resp, err := mrt.RoundTrip(mockReq)
-				if test.expectErr {
-					assert.Error(t, err)
-				} else {
-					assert.NoError(t, err)
-					assert.NotNil(t, resp)
-					assert.True(t, middlewareCalled)
-					assert.True(t, respHandlerCalled)
-				}
-			} else {
-				assert.Panics(t, func() {
-					_, _ = mrt.RoundTrip(mockReq)
-				})
-			}
-		})
-	}
 }
 
 func TestRetryRoundTrip(t *testing.T) {

--- a/http/metrics.go
+++ b/http/metrics.go
@@ -179,6 +179,9 @@ func (metricsRT MetricsRoundTripper) RoundTrip(r *http.Request) (*http.Response,
 	// Make the request
 	var resp *http.Response
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(durationSec float64) {
+		if resp == nil {
+			return
+		}
 		labels := prometheus.Labels{
 			"path":        r.URL.Path,
 			"status_code": strconv.Itoa(resp.StatusCode),

--- a/http/metrics.go
+++ b/http/metrics.go
@@ -162,7 +162,7 @@ func (m Metrics) Middleware(next http.Handler) http.Handler {
 	})
 }
 
-// MiddlewareRoundTripper implements a proxied net/http RoundTripper so that http requests may be
+// MetricsRoundTripper implements a proxied net/http RoundTripper so that http requests may be
 // measured with metrics
 type MetricsRoundTripper struct {
 	RoundTripper http.RoundTripper

--- a/http/metrics.go
+++ b/http/metrics.go
@@ -173,7 +173,7 @@ type MetricsRoundTripper struct {
 func (metricsRT MetricsRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	// Ensure the RoundTripper was set on the MiddlewareRoundTripper
 	if metricsRT.RoundTripper == nil {
-		panic("no roundtripper provided to middleware round tripper")
+		panic("no roundtripper provided to metrics round tripper")
 	}
 
 	// Make the request

--- a/http/metrics_test.go
+++ b/http/metrics_test.go
@@ -138,56 +138,83 @@ func TestMiddleware(t *testing.T) {
 }
 
 func TestClientMiddleware(t *testing.T) {
-	metrics := NewMetrics(nil, true)
-
-	mockReq := httptest.NewRequest("GET", "/path", nil)
-	req, respHandler, err := metrics.ClientMiddleware(mockReq)
-	assert.NotNil(t, req)
-	assert.NoError(t, err)
-	assert.NoError(t, respHandler(&http.Response{StatusCode: http.StatusOK}))
-
-	// Expected prometheus labels after this request
-	labels := prometheus.Labels{
-		"path":        "/path",
-		"status_code": "200",
+	tests := []struct {
+		name         string
+		roundTripper http.RoundTripper
+		expectPanic  bool
+	}{
+		{
+			"no roundtripper results in a panic",
+			nil,
+			true,
+		},
+		{
+			"http requests are measured and status code is recorded on request",
+			&MockRoundTripper{responseStatusCodes: []int{http.StatusOK}, createErr: false},
+			false,
+		},
 	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			metricsRT := MetricsRoundTripper{
+				RoundTripper: test.roundTripper,
+				metrics:      NewMetrics(nil, true),
+			}
+			mockReq := httptest.NewRequest("GET", "/path", nil)
+			if test.expectPanic {
+				assert.Panics(t, func() {
+					_, _ = metricsRT.RoundTrip(mockReq)
+				})
+			} else {
+				resp, err := metricsRT.RoundTrip(mockReq)
+				assert.NotNil(t, resp)
+				assert.NoError(t, err)
 
-	// Check duration histogram
-	histogram, err := metrics.clientDuration.GetMetricWith(labels)
-	assert.NoError(t, err)
-	pb := &dto.Metric{}
-	assert.NoError(t, histogram.(prometheus.Histogram).Write(pb))
-	buckets := pb.Histogram.GetBucket()
-	assert.NotEmpty(t, buckets)
-	for _, bucket := range pb.Histogram.GetBucket() {
-		// Choose a bucket which gives a full second to this test and ensure we have a count of at
-		// least one. This just ensures that our timer is working. This request should never take
-		// longer than a millisecond, but we hugely increase the threshold to ensure we dont
-		// introduce tests that periodically fail for no clear reason.
-		if bucket.GetUpperBound() >= 1.0 {
-			assert.Equal(t, uint64(1), bucket.GetCumulativeCount())
-			break
-		}
+				// Expected prometheus labels after this request
+				labels := prometheus.Labels{
+					"path":        "/path",
+					"status_code": "200",
+				}
+
+				// Check duration histogram
+				histogram, err := metricsRT.metrics.clientDuration.GetMetricWith(labels)
+				assert.NoError(t, err)
+				pb := &dto.Metric{}
+				assert.NoError(t, histogram.(prometheus.Histogram).Write(pb))
+				buckets := pb.Histogram.GetBucket()
+				assert.NotEmpty(t, buckets)
+				for _, bucket := range pb.Histogram.GetBucket() {
+					// Choose a bucket which gives a full second to this test and ensure we have a count of at
+					// least one. This just ensures that our timer is working. This request should never take
+					// longer than a millisecond, but we hugely increase the threshold to ensure we dont
+					// introduce tests that periodically fail for no clear reason.
+					if bucket.GetUpperBound() >= 1.0 {
+						assert.Equal(t, uint64(1), bucket.GetCumulativeCount())
+						break
+					}
+				}
+
+				// Check content-length histogram
+				contentLengthHistogram, err := metricsRT.metrics.clientContentLength.GetMetricWith(labels)
+				assert.NoError(t, err)
+				pb = &dto.Metric{}
+				assert.NoError(t, contentLengthHistogram.(prometheus.Histogram).Write(pb))
+				buckets = pb.Histogram.GetBucket()
+				assert.NotEmpty(t, buckets)
+
+				// Check request counter
+				counter, err := metricsRT.metrics.clientCounter.GetMetricWith(labels)
+				assert.NoError(t, err)
+				pb = &dto.Metric{}
+				assert.NoError(t, counter.Write(pb))
+				assert.Equal(t, 1, int(pb.Counter.GetValue()))
+			}
+			prometheus.Unregister(metricsRT.metrics.duration)
+			prometheus.Unregister(metricsRT.metrics.clientDuration)
+			prometheus.Unregister(metricsRT.metrics.contentLength)
+			prometheus.Unregister(metricsRT.metrics.clientContentLength)
+			prometheus.Unregister(metricsRT.metrics.counter)
+			prometheus.Unregister(metricsRT.metrics.clientCounter)
+		})
 	}
-	prometheus.Unregister(metrics.duration)
-	prometheus.Unregister(metrics.clientDuration)
-
-	// Check content-length histogram
-	contentLengthHistogram, err := metrics.clientContentLength.GetMetricWith(labels)
-	assert.NoError(t, err)
-	pb = &dto.Metric{}
-	assert.NoError(t, contentLengthHistogram.(prometheus.Histogram).Write(pb))
-	buckets = pb.Histogram.GetBucket()
-	assert.NotEmpty(t, buckets)
-	prometheus.Unregister(metrics.contentLength)
-	prometheus.Unregister(metrics.clientContentLength)
-
-	// Check request counter
-	counter, err := metrics.clientCounter.GetMetricWith(labels)
-	assert.NoError(t, err)
-	pb = &dto.Metric{}
-	assert.NoError(t, counter.Write(pb))
-	assert.Equal(t, 1, int(pb.Counter.GetValue()))
-	prometheus.Unregister(metrics.counter)
-	prometheus.Unregister(metrics.clientCounter)
 }

--- a/http/metrics_test.go
+++ b/http/metrics_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/spothero/tools/http/roundtrip"
 	"github.com/spothero/tools/http/writer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -150,7 +151,7 @@ func TestClientMiddleware(t *testing.T) {
 		},
 		{
 			"http requests are measured and status code is recorded on request",
-			&MockRoundTripper{responseStatusCodes: []int{http.StatusOK}, createErr: false},
+			&roundtrip.MockRoundTripper{ResponseStatusCodes: []int{http.StatusOK}, CreateErr: false},
 			false,
 		},
 	}

--- a/http/metrics_test.go
+++ b/http/metrics_test.go
@@ -138,7 +138,7 @@ func TestMiddleware(t *testing.T) {
 	prometheus.Unregister(metrics.clientCounter)
 }
 
-func TestClientMiddleware(t *testing.T) {
+func TestMetricsRoundTrip(t *testing.T) {
 	tests := []struct {
 		name         string
 		roundTripper http.RoundTripper

--- a/http/roundtrip/mock_round_tripper.go
+++ b/http/roundtrip/mock_round_tripper.go
@@ -1,0 +1,37 @@
+// Copyright 2020 SpotHero
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package roundtrip
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// This roundtripper is a noop and is intended for use only within tests.
+type MockRoundTripper struct {
+	ResponseStatusCodes []int
+	CreateErr           bool
+	CallNumber          int
+}
+
+// RoundTrip Performs a "noop" round trip. It is intended for use only within tests.
+func (mockRT *MockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	currCallNumber := mockRT.CallNumber
+	mockRT.CallNumber++
+	if mockRT.CreateErr {
+		return nil, fmt.Errorf("error in roundtripper")
+	}
+	return &http.Response{StatusCode: mockRT.ResponseStatusCodes[currCallNumber]}, nil
+}

--- a/http/roundtrip/mock_round_tripper_test.go
+++ b/http/roundtrip/mock_round_tripper_test.go
@@ -1,0 +1,58 @@
+// Copyright 2020 SpotHero
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package roundtrip
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoundTrip(t *testing.T) {
+	tests := []struct {
+		name        string
+		statusCodes []int
+		expectErr   bool
+	}{
+		{
+			"the set status code is returned with no error",
+			[]int{http.StatusOK},
+			false,
+		},
+		{
+			"if an error is requested, an error is returned",
+			[]int{http.StatusOK},
+			true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mrt := MockRoundTripper{
+				ResponseStatusCodes: test.statusCodes,
+				CreateErr:           test.expectErr,
+			}
+			resp, err := mrt.RoundTrip(nil)
+			if test.expectErr {
+				assert.Error(t, err)
+				assert.Nil(t, resp)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+			}
+		})
+	}
+}

--- a/jose/middleware.go
+++ b/jose/middleware.go
@@ -94,21 +94,21 @@ func GetHTTPServerMiddleware(jh JOSEHandler, authRequired bool) func(next http.H
 	}
 }
 
-// AuthRoundTripper implements an http.RoundTripper which passes along any auth headers automatically
-type AuthRoundTripper struct {
+// RoundTripper implements an http.RoundTripper which passes along any auth headers automatically
+type RoundTripper struct {
 	RoundTripper http.RoundTripper
 }
 
 // RoundTrip is intended for use in HTTP Clients and it propagates the Authorization
 // headers on outgoing HTTP calls automatically
-func (art AuthRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+func (rt RoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	// Ensure the RoundTripper was set on the MiddlewareRoundTripper
-	if art.RoundTripper == nil {
+	if rt.RoundTripper == nil {
 		panic("no roundtripper provided to auth round tripper")
 	}
 
 	if jwtData, ok := r.Context().Value(JWTClaimKey).(string); ok {
 		r.Header.Set(authHeader, fmt.Sprintf("%s%s", bearerPrefix, jwtData))
 	}
-	return art.RoundTripper.RoundTrip(r)
+	return rt.RoundTripper.RoundTrip(r)
 }

--- a/jose/middleware.go
+++ b/jose/middleware.go
@@ -94,11 +94,21 @@ func GetHTTPServerMiddleware(jh JOSEHandler, authRequired bool) func(next http.H
 	}
 }
 
-// HTTPClientMiddleware is middleware for use in HTTP Clients which propagates the Authorization
-// headers
-func HTTPClientMiddleware(r *http.Request) (*http.Request, func(*http.Response) error, error) {
+// AuthRoundTripper implements an http.RoundTripper which passes along any auth headers automatically
+type AuthRoundTripper struct {
+	RoundTripper http.RoundTripper
+}
+
+// RoundTrip is intended for use in HTTP Clients and it propagates the Authorization
+// headers on outgoing HTTP calls automatically
+func (art AuthRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	// Ensure the RoundTripper was set on the MiddlewareRoundTripper
+	if art.RoundTripper == nil {
+		panic("no roundtripper provided to auth round tripper")
+	}
+
 	if jwtData, ok := r.Context().Value(JWTClaimKey).(string); ok {
 		r.Header.Set(authHeader, fmt.Sprintf("%s%s", bearerPrefix, jwtData))
 	}
-	return r, func(resp *http.Response) error { return nil }, nil
+	return art.RoundTripper.RoundTrip(r)
 }

--- a/jose/middleware_test.go
+++ b/jose/middleware_test.go
@@ -204,15 +204,15 @@ func TestRoundTrip(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			art := AuthRoundTripper{RoundTripper: test.roundTripper}
+			rt := RoundTripper{RoundTripper: test.roundTripper}
 			if test.expectPanic {
 				assert.Panics(t, func() {
-					_, _ = art.RoundTrip(nil)
+					_, _ = rt.RoundTrip(nil)
 				})
 			} else {
 				mockReq := httptest.NewRequest("GET", "/path", nil)
 				mockReq = mockReq.WithContext(context.WithValue(mockReq.Context(), JWTClaimKey, "jwt"))
-				resp, err := art.RoundTrip(mockReq)
+				resp, err := rt.RoundTrip(mockReq)
 				assert.NoError(t, err)
 				assert.NotNil(t, resp)
 			}

--- a/jose/middleware_test.go
+++ b/jose/middleware_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/spothero/tools/http/roundtrip"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -184,13 +185,37 @@ func TestGetHTTPServerMiddleware(t *testing.T) {
 	}
 }
 
-func TestHTTPClientMiddleware(t *testing.T) {
-	mockReq := httptest.NewRequest("GET", "/path", nil)
-	mockReq = mockReq.WithContext(context.WithValue(mockReq.Context(), JWTClaimKey, "jwt"))
-	req, respHandler, err := HTTPClientMiddleware(mockReq)
-	assert.NoError(t, err)
-	assert.NotNil(t, respHandler)
-	assert.NotNil(t, req)
-	assert.NoError(t, respHandler(&http.Response{}))
-	assert.Equal(t, mockReq.Header.Get(authHeader), fmt.Sprintf("%s%s", bearerPrefix, "jwt"))
+func TestRoundTrip(t *testing.T) {
+	tests := []struct {
+		name         string
+		roundTripper http.RoundTripper
+		expectPanic  bool
+	}{
+		{
+			"no round tripper results in a panic",
+			nil,
+			true,
+		},
+		{
+			"if auth data is present in the context it is set on outbound requests",
+			&roundtrip.MockRoundTripper{ResponseStatusCodes: []int{http.StatusOK}, CreateErr: false},
+			false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			art := AuthRoundTripper{RoundTripper: test.roundTripper}
+			if test.expectPanic {
+				assert.Panics(t, func() {
+					_, _ = art.RoundTrip(nil)
+				})
+			} else {
+				mockReq := httptest.NewRequest("GET", "/path", nil)
+				mockReq = mockReq.WithContext(context.WithValue(mockReq.Context(), JWTClaimKey, "jwt"))
+				resp, err := art.RoundTrip(mockReq)
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+			}
+		})
+	}
 }

--- a/log/grpc_interceptors.go
+++ b/log/grpc_interceptors.go
@@ -41,11 +41,11 @@ func UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.Una
 	newCtx := NewContext(ctx, requestLogger)
 	resp, err := handler(newCtx, req)
 	code := status.Code(err)
-	Get(newCtx).Check(grpc_zap.DefaultCodeToLevel(code), "returning response").Write(
+	Get(newCtx).With(
 		zap.String("grpc.code", code.String()),
 		zap.Duration("grpc.duration", time.Since(startTime)),
 		zap.Error(err),
-	)
+	).Check(grpc_zap.DefaultCodeToLevel(code), "returning response").Write()
 	return resp, err
 }
 
@@ -65,11 +65,11 @@ func StreamServerInterceptor(srv interface{}, stream grpc.ServerStream, info *gr
 	wrapped.WrappedContext = newCtx
 	err := handler(srv, wrapped)
 	code := status.Code(err)
-	Get(newCtx).Check(grpc_zap.DefaultCodeToLevel(code), "returning response").Write(
+	Get(newCtx).With(
 		zap.String("grpc.code", code.String()),
 		zap.Duration("grpc.duration", time.Since(startTime)),
 		zap.Error(err),
-	)
+	).Check(grpc_zap.DefaultCodeToLevel(code), "returning response").Write()
 	return err
 }
 

--- a/log/middleware.go
+++ b/log/middleware.go
@@ -102,11 +102,9 @@ func (rt RoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 
 // SQLMiddleware debug logs requests made against SQL databases.
 func SQLMiddleware(ctx context.Context, queryName, query string, args ...interface{}) (context.Context, sqlMiddleware.MiddlewareEnd, error) {
-	logger = Get(ctx)
+	logger = Get(ctx).With(zap.String("query", query))
 	if queryName != "" {
-		logger = logger.With(zap.String("query", query), zap.String("query_name", queryName))
-	} else {
-		logger = logger.With(zap.String("query", query))
+		logger = logger.With(zap.String("query_name", queryName))
 	}
 	logger.Debug("attempting sql query")
 	mwEnd := func(ctx context.Context, queryName, query string, queryErr error, args ...interface{}) (context.Context, error) {


### PR DESCRIPTION
Refactor HTTP "Middleware" to instead be a series of nested roundtrippers. This is cleaner and removes unnecessary bookkeeping and closures.

No impact on any clients using this code.