### PR TITLE
basic auth0 support

### DIFF
--- a/jose/auth0.go
+++ b/jose/auth0.go
@@ -1,0 +1,47 @@
+// Copyright 2020 SpotHero
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jose
+
+import (
+	"context"
+)
+
+// Auth0CtxKey is the type used to uniquely place the cognito claim in the context
+type Auth0CtxKey int
+
+// Auth0ClaimKey is the value used to uniquely place the cognito claim within the context
+const Auth0ClaimKey Auth0CtxKey = iota
+
+// Auth0Generator satisfies the ClaimGenerator interface, allowing middleware to create
+// intermediate Claim objects without specific knowledge of the underlying implementing types.
+type Auth0Generator struct{}
+
+// Auth0Claim defines a JWT Claim for tokens issued by the AWS Auth0 Service
+type Auth0Claim struct {
+	UserID   string `json:"sub"`
+	ClientID string `json:"aud"`
+	Email    string `json:"email"`
+}
+
+// New satisfies the ClaimGenerator interface, returning an empty claim for use with JOSE parsing
+// and validation.
+func (cg Auth0Generator) New() Claim {
+	return &Auth0Claim{}
+}
+
+// NewContext registers a claim to a given context and returns that new context
+func (cc Auth0Claim) NewContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, Auth0ClaimKey, &cc)
+}

--- a/jose/auth0.go
+++ b/jose/auth0.go
@@ -28,7 +28,9 @@ const Auth0ClaimKey Auth0CtxKey = iota
 // intermediate Claim objects without specific knowledge of the underlying implementing types.
 type Auth0Generator struct{}
 
-// Auth0Claim defines a JWT Claim for tokens issued by the AWS Auth0 Service
+// Auth0Claim defines a JWT Claim for tokens issued by Auth0. Note that for Client Credentials
+// JWTs, ClientID will be populated. For normal User authentication UserID will be populated. Both
+// UserID and ClientID will not be populated together.
 type Auth0Claim struct {
 	UserID   string `json:"sub"`
 	ClientID string `json:"aud"`

--- a/jose/auth0_test.go
+++ b/jose/auth0_test.go
@@ -1,0 +1,38 @@
+// Copyright 2020 SpotHero
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jose
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuth0GeneratorNew(t *testing.T) {
+	assert.Equal(t, &Auth0Claim{}, Auth0Generator{}.New())
+}
+
+func TestAuth0ClaimNewContext(t *testing.T) {
+	ctx := context.Background()
+	cc := Auth0Claim{
+		UserID:   "abc123",
+		ClientID: "abc123",
+		Email:    "email",
+	}
+
+	expected := context.WithValue(context.Background(), Auth0ClaimKey, &cc)
+	assert.Equal(t, expected, cc.NewContext(ctx))
+}

--- a/service/service.go
+++ b/service/service.go
@@ -99,7 +99,12 @@ func (c Config) ServerCmd(
 	// Tracing Config
 	tc := tracing.Config{ServiceName: c.Name}
 	// Jose Config
-	jc := jose.Config{ClaimGenerators: []jose.ClaimGenerator{jose.CognitoGenerator{}}}
+	jc := jose.Config{
+		ClaimGenerators: []jose.ClaimGenerator{
+			jose.CognitoGenerator{},
+			jose.Auth0Generator{},
+		},
+	}
 	cmd := &cobra.Command{
 		Use:              c.Name,
 		Short:            shortDescription,


### PR DESCRIPTION
Adds Auth0 support to tools. This is largely in support of CRaiG and vehicles work for @wilsoniya and @theisenmark. Once this is merged, incoming JWTs will automatically be parsed for ClientID / UserID information which will then be placed into the context for all downstream services.

See here: https://auth0.com/docs/scopes/current/sample-use-cases#add-custom-claims-to-a-token for information on where standard OpenID fields came from