### PR TITLE
Use specified metrics instance in default http client

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -67,7 +67,7 @@ func NewDefaultClient(metrics Metrics, roundTripper http.RoundTripper) http.Clie
 	}
 	tracingRoundTripper := tracing.RoundTripper{RoundTripper: retryRoundTripper}
 	loggingRoundTripper := log.RoundTripper{RoundTripper: tracingRoundTripper}
-	metricsRoundTripper := MetricsRoundTripper{RoundTripper: loggingRoundTripper}
+	metricsRoundTripper := MetricsRoundTripper{RoundTripper: loggingRoundTripper, metrics: metrics}
 	joseRoundTripper := jose.RoundTripper{RoundTripper: metricsRoundTripper}
 	return http.Client{Transport: joseRoundTripper}
 }

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -29,13 +29,15 @@ import (
 )
 
 func TestNewDefaultClient(t *testing.T) {
-	client := NewDefaultClient(NewMetrics(prometheus.NewRegistry(), true), nil)
+	metrics := NewMetrics(prometheus.NewRegistry(), true)
+	client := NewDefaultClient(metrics, nil)
 	assert.NotNil(t, client)
 	jrt, ok := client.Transport.(jose.RoundTripper)
 	assert.True(t, ok)
 
 	mrt, ok := jrt.RoundTripper.(MetricsRoundTripper)
 	assert.True(t, ok)
+	assert.Equal(t, metrics, mrt.metrics)
 
 	lrt, ok := mrt.RoundTripper.(log.RoundTripper)
 	assert.True(t, ok)


### PR DESCRIPTION
Quick bugfix to use the specified metrics instance in the default http client. 