### PR TITLE
env set in wrong place for sentry

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -94,10 +94,7 @@ func (c Config) ServerCmd(
 		Cores: []zapcore.Core{&sentry.Core{}},
 	}
 	// Sentry Config
-	sc := sentry.Config{
-		Environment: c.Environment,
-		AppVersion:  c.Version,
-	}
+	sc := sentry.Config{AppVersion: c.Version}
 	// Tracing Config
 	tc := tracing.Config{ServiceName: c.Name}
 	// Jose Config
@@ -114,6 +111,8 @@ func (c Config) ServerCmd(
 		Version:          fmt.Sprintf("%s (%s)", c.Version, c.GitSHA),
 		PersistentPreRun: cli.CobraBindEnvironmentVariables(strings.Replace(c.Name, "-", "_", -1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			sc.Environment = c.Environment
+
 			if err := c.CheckFlags(); err != nil {
 				return err
 			}


### PR DESCRIPTION
Sadly the environment setting for the sentry config was set too early, so all of our deployments were filing their errors under `local`, always. This enables us to have environment routing work correctly.