### PR TITLE
rm auth required

### DIFF
--- a/jose/cli.go
+++ b/jose/cli.go
@@ -20,5 +20,4 @@ import "github.com/spf13/pflag"
 func (c *Config) RegisterFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&c.JSONWebKeySetURL, "jose-jwks-url", c.JSONWebKeySetURL, "JSON Web Key Set (JWKS) URL for JSON Web Token (JWT) Verification")
 	flags.StringVar(&c.ValidIssuer, "jose-valid-issuer", c.ValidIssuer, "Valid issuer (iss) of JWT tokens in this environment")
-	flags.BoolVar(&c.AuthRequired, "jose-auth-required", false, "HTTP Middleware Only: If true (default), return a 4XX error if the `Authorization` header is missing or invalid. If false, ignores missing `Authorization`.")
 }

--- a/jose/cli_test.go
+++ b/jose/cli_test.go
@@ -35,8 +35,4 @@ func TestRegisterFlags(t *testing.T) {
 	vi, err := flags.GetString("jose-valid-issuer")
 	assert.NoError(t, err)
 	assert.Equal(t, "", vi)
-
-	ar, err := flags.GetBool("jose-auth-required")
-	assert.NoError(t, err)
-	assert.False(t, ar)
 }

--- a/jose/grpc_interceptors_test.go
+++ b/jose/grpc_interceptors_test.go
@@ -34,67 +34,33 @@ func TestGetContextAuth(t *testing.T) {
 		jwt                 string
 		parseJWTError       bool
 		expectClaim         bool
-		authRequired        bool
 		expectErr           bool
 		errorCode           codes.Code
 	}{
 		{
-			"no auth metadata results in no claim, auth not required, no error returned",
+			"no auth metadata results in no claim, no error returned",
 			false,
 			"",
 			"",
-			false,
 			false,
 			false,
 			false,
 			codes.OK,
 		}, {
-			"failed jwt parsings are rejected, auth not required, no error returned",
+			"failed jwt parsings are rejected",
 			true,
 			"Bearer fake.jwt.header",
 			"fake.jwt.header",
 			true,
 			false,
-			false,
-			false,
-			codes.OK,
-		}, {
-			"with auth: no auth metadata results in no claim and a 401",
-			false,
-			"",
-			"",
-			false,
-			false,
-			true,
 			true,
 			codes.Unauthenticated,
-		}, {
-			"failed jwt parsings are rejected, auth required",
-			true,
-			"Bearer fake.jwt.header",
-			"fake.jwt.header",
-			true,
-			false,
-			true,
-			true,
-			codes.Unauthenticated,
-		}, {
-			"failed jwt parsings, auth not required, no error returned",
-			true,
-			"Bearer fake.jwt.header",
-			"fake.jwt.header",
-			true,
-			false,
-			false,
-			false,
-			codes.OK,
 		}, {
 			"jwt tokens are parsed and placed in context when present",
 			true,
 			"Bearer fake.jwt.header",
 			"fake.jwt.header",
 			false,
-			true,
 			true,
 			false,
 			codes.OK,
@@ -116,7 +82,7 @@ func TestGetContextAuth(t *testing.T) {
 				handler.GetClaims(),
 			).Return(parseErr)
 
-			joseInterceptor := GetContextAuth(handler, test.authRequired)
+			joseInterceptor := GetContextAuth(handler)
 
 			ctx := context.Background()
 			if test.authMetadataPresent {

--- a/jose/jwt.go
+++ b/jose/jwt.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/spothero/tools/log"
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
@@ -74,8 +75,10 @@ const JWTClaimKey JWTHeaderCtxKey = iota
 
 // NewJOSE creates and returns a JOSE client for use.
 func (c Config) NewJOSE() (JOSE, error) {
+	logger := log.Get(context.Background())
 	if len(c.JSONWebKeySetURL) == 0 {
-		return JOSE{}, fmt.Errorf("no jwks url specified")
+		logger.Warn("no jwks url specified - no authentication will be performed")
+		return JOSE{}, nil
 	}
 
 	// Fetch JSON Web Key Sets from the specified URL

--- a/jose/jwt_test.go
+++ b/jose/jwt_test.go
@@ -43,10 +43,10 @@ func TestNewJOSE(t *testing.T) {
 			true,
 			"",
 		}, {
-			"missing JWKS URL results in an error",
+			"missing JWKS URL results in an empty JOSE config",
 			[]byte("{\"keys\": []}"),
 			http.StatusOK,
-			true,
+			false,
 			false,
 			"",
 		}, {

--- a/jose/middleware.go
+++ b/jose/middleware.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/spothero/tools/log"
+	"go.uber.org/zap"
 )
 
 // authHeader defines the name of the header containing the JWT authorization data
@@ -31,7 +32,6 @@ const authHeader = "Authorization"
 const bearerPrefix = "Bearer "
 
 const (
-	authHeaderNotFound   = "no authorization header found"
 	bearerPrefixNotFound = "authorization header did not include bearer prefix"
 	invalidBearerToken   = "bearer token is invalid"
 	noBearerToken        = "no authorization bearer token found"
@@ -41,54 +41,40 @@ const (
 // header, if present, on all incoming HTTP requests. If an Authorization header is found, this
 // middleware attempts to parse and validate that value as a JWT with the configured Credential
 // types for the given JOSE provider.
-func GetHTTPServerMiddleware(jh JOSEHandler, authRequired bool) func(next http.Handler) http.Handler {
+func GetHTTPServerMiddleware(jh JOSEHandler) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			logger := log.Get(r.Context())
 			authHeader := r.Header.Get(authHeader)
-			var parseErrMsg string
 			if len(authHeader) == 0 {
-				logger.Debug(authHeaderNotFound)
-				parseErrMsg = authHeaderNotFound
+				logger.Debug("no bearer token found")
+				next.ServeHTTP(w, r)
+				return
 			}
 
-			if len(parseErrMsg) == 0 && !strings.HasPrefix(authHeader, bearerPrefix) {
+			if !strings.HasPrefix(authHeader, bearerPrefix) {
 				logger.Debug(bearerPrefixNotFound)
-				parseErrMsg = bearerPrefixNotFound
+				w.Header().Set("WWW-Authenticate", "Bearer")
+				http.Error(w, bearerPrefixNotFound, http.StatusUnauthorized)
+				return
 			}
 
-			var claims []Claim
-			bearerToken := ""
-			if len(parseErrMsg) == 0 {
-				claims = jh.GetClaims()
-				bearerToken = strings.TrimPrefix(authHeader, bearerPrefix)
-				err := jh.ParseValidateJWT(bearerToken, claims...)
-				if err != nil {
-					logger.Debug(err.Error())
-					parseErrMsg = invalidBearerToken
-				}
-			}
-			if len(parseErrMsg) == 0 {
-				// Populate each claim on the context, if any
-				for _, claim := range claims {
-					r = r.WithContext(claim.NewContext(r.Context()))
-				}
-				// Set the bearer token on the context so it can be passed to any downstream services
-				r = r.WithContext(context.WithValue(r.Context(), JWTClaimKey, bearerToken))
+			claims := jh.GetClaims()
+			bearerToken := strings.TrimPrefix(authHeader, bearerPrefix)
+			err := jh.ParseValidateJWT(bearerToken, claims...)
+			if err != nil {
+				logger.Debug("invalid bearer token", zap.Error(err))
+				http.Error(w, invalidBearerToken, http.StatusForbidden)
+				return
 			}
 
-			if len(parseErrMsg) != 0 {
-				logger.Debug(parseErrMsg)
-				if authRequired {
-					httpStatus := http.StatusForbidden
-					if parseErrMsg == bearerPrefixNotFound || parseErrMsg == authHeaderNotFound {
-						w.Header().Set("WWW-Authenticate", "Bearer")
-						httpStatus = http.StatusUnauthorized
-					}
-					http.Error(w, parseErrMsg, httpStatus)
-					return
-				}
+			// Populate each claim on the context, if any
+			for _, claim := range claims {
+				r = r.WithContext(claim.NewContext(r.Context()))
 			}
+			// Set the bearer token on the context so it can be passed to any downstream services
+			r = r.WithContext(context.WithValue(r.Context(), JWTClaimKey, bearerToken))
+
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/jose/middleware.go
+++ b/jose/middleware.go
@@ -34,7 +34,6 @@ const bearerPrefix = "Bearer "
 const (
 	bearerPrefixNotFound = "authorization header did not include bearer prefix"
 	invalidBearerToken   = "bearer token is invalid"
-	noBearerToken        = "no authorization bearer token found"
 )
 
 // GetHTTPServerMiddleware returns an HTTP middleware function which extracts the Authorization

--- a/service/service.go
+++ b/service/service.go
@@ -140,26 +140,24 @@ func (c Config) ServerCmd(
 				grpcprom.StreamServerInterceptor,
 			}
 
-			// If the user has requested JOSE Auth, add JOSE Auth interceptors
-			if jc.AuthRequired {
-				jh, err := jc.NewJOSE()
-				if err != nil {
-					return err
-				}
-				joseInterceptorFunc := jose.GetContextAuth(jh, jc.AuthRequired)
-				grpcConfig.UnaryInterceptors = append(
-					grpcConfig.UnaryInterceptors,
-					grpcauth.UnaryServerInterceptor(joseInterceptorFunc),
-				)
-				grpcConfig.StreamInterceptors = append(
-					grpcConfig.StreamInterceptors,
-					grpcauth.StreamServerInterceptor(joseInterceptorFunc),
-				)
-				httpConfig.Middleware = append(
-					httpConfig.Middleware,
-					jose.GetHTTPServerMiddleware(jh, jc.AuthRequired),
-				)
+			// Add JOSE Auth interceptors
+			jh, err := jc.NewJOSE()
+			if err != nil {
+				return err
 			}
+			joseInterceptorFunc := jose.GetContextAuth(jh)
+			grpcConfig.UnaryInterceptors = append(
+				grpcConfig.UnaryInterceptors,
+				grpcauth.UnaryServerInterceptor(joseInterceptorFunc),
+			)
+			grpcConfig.StreamInterceptors = append(
+				grpcConfig.StreamInterceptors,
+				grpcauth.StreamServerInterceptor(joseInterceptorFunc),
+			)
+			httpConfig.Middleware = append(
+				httpConfig.Middleware,
+				jose.GetHTTPServerMiddleware(jh),
+			)
 
 			// Add panic handlers to the middleware. Panic handlers should always come last,
 			// because they can help recover error state such that it is correctly handled by


### PR DESCRIPTION
This gets rid of the concept of a globally enforced auth. We'll only ever enforce it on GRPC endpoints, HTTP routers, or HTTP Handlers. This was a broken idea that didn't work correctly.