### PR TITLE
Add basic pagination support

### DIFF
--- a/pagination/paginator.go
+++ b/pagination/paginator.go
@@ -1,0 +1,50 @@
+package pagination
+
+// IDExtractor extracts an ID from an untyped parameter. It's expected that
+// IDExtractors will downcast element to the expected type and panic if the
+// downcast fails.
+type IDExtractor func(element interface{}) interface{}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// Pageable is an type that can be paginated when present in a collection.
+type Pageable interface {
+	// ExtractID derives an identifier that is guaranteed to be unique relative
+	// to any elements with which it may coexist in a given collection
+	ExtractID() string
+}
+
+// GetPageAfterID paginates elements. The first element of the returned page
+// directly follows the element in elements having an ID equivalent to after. At
+// most pageSize results are included in the returned page.
+func GetPageAfterID(
+	elements []Pageable,
+	after string,
+	pageSize uint,
+) []Pageable {
+	if after == "" {
+		// zero-after indicates start with the first page
+		return elements[0:minInt(int(pageSize), len(elements))]
+	}
+
+	afterIdx := -1
+	for idx, element := range elements {
+		if after == element.ExtractID() {
+			afterIdx = idx
+		}
+	}
+
+	if afterIdx == -1 {
+		return []Pageable{}
+	}
+
+	start := afterIdx + 1
+	end := minInt(start+int(pageSize), len(elements))
+
+	return elements[start:end]
+}

--- a/pagination/paginator_test.go
+++ b/pagination/paginator_test.go
@@ -1,0 +1,186 @@
+package pagination
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testStruct struct {
+	id string
+}
+
+func (ts testStruct) ExtractID() string {
+	return ts.id
+}
+
+func TestMinInt(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name        string
+		first int
+		second int
+		expected int
+	}{
+		{
+			name:     "first input is larger",
+			first: 10,
+			second: 20,
+			expected: 10,
+		},
+		{
+			name:     "second input is larger",
+			first: 20,
+			second: 10,
+			expected: 10,
+		},
+		{
+			name:     "equal inputs",
+			first: 10,
+			second: 10,
+			expected: 10,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := minInt(test.first, test.second)
+			assert.Equal(actual, test.expected)
+		})
+	}
+}
+
+func TestGetPageByID(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name        string
+		after       string
+		pageSize    uint
+		input       []testStruct
+		expected    []testStruct
+		panicString string
+	}{
+		{
+			name:     "paging from the beginning",
+			after:    "",
+			pageSize: 1,
+			input: []testStruct{
+				{id: "a"},
+				{id: "b"},
+			},
+			expected: []testStruct{
+				{id: "a"},
+			},
+			panicString: "",
+		},
+		{
+			name:     "after offset",
+			after:    "b",
+			pageSize: 2,
+			input: []testStruct{
+				{id: "a"},
+				{id: "b"},
+				{id: "c"},
+				{id: "d"},
+				{id: "e"},
+				{id: "f"},
+			},
+			expected: []testStruct{
+				{id: "c"},
+				{id: "d"},
+			},
+			panicString: "",
+		},
+		{
+			name:     "after offset til the end of the resultset",
+			after:    "b",
+			pageSize: 10000,
+			input: []testStruct{
+				{id: "a"},
+				{id: "b"},
+				{id: "c"},
+				{id: "d"},
+				{id: "e"},
+				{id: "f"},
+			},
+			expected: []testStruct{
+				{id: "c"},
+				{id: "d"},
+				{id: "e"},
+				{id: "f"},
+			},
+			panicString: "",
+		},
+		{
+			name:     "complete resultset",
+			after:    "",
+			pageSize: 6,
+			input: []testStruct{
+				{id: "a"},
+				{id: "b"},
+				{id: "c"},
+				{id: "d"},
+				{id: "e"},
+				{id: "f"},
+			},
+			expected: []testStruct{
+				{id: "a"},
+				{id: "b"},
+				{id: "c"},
+				{id: "d"},
+				{id: "e"},
+				{id: "f"},
+			},
+			panicString: "",
+		},
+		{
+			name:     "nonexistent after",
+			after:    "bogus",
+			pageSize: 6,
+			input: []testStruct{
+				{id: "a"},
+				{id: "b"},
+				{id: "c"},
+				{id: "d"},
+				{id: "e"},
+				{id: "f"},
+			},
+			expected:    []testStruct{},
+			panicString: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			elements := make([]Pageable, len(test.input))
+			for idx, item := range test.input {
+				elements[idx] = item
+			}
+
+			var page []Pageable
+			if test.panicString == "" {
+				assert.NotPanics(func() {
+					page = GetPageAfterID(elements, test.after, test.pageSize)
+				})
+			} else {
+				assert.PanicsWithValue(test.panicString, func() {
+					page = GetPageAfterID(elements, test.after, test.pageSize)
+				})
+			}
+
+			actual := make([]testStruct, len(page))
+			for idx, element := range page {
+				typed, ok := element.(testStruct)
+				if !ok {
+					panic("failed downcast in reconstituting typed array")
+				}
+
+				actual[idx] = typed
+			}
+
+			assert.Equal(actual, test.expected)
+		})
+	}
+}


### PR DESCRIPTION
**Description**
This is the same pagination code originally written by @wilsoniya for CRAiG - https://github.com/spothero/craig/pull/40
I'm trying to reuse it in `reservations` so I figure it's a good candidate to extract into our common tooling.
