### PR TITLE
[PMP-542] use first 6 chars of git sha for logging

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -90,7 +90,7 @@ func (c Config) ServerCmd(
 		UseDevelopmentLogger: true,
 		Fields: map[string]interface{}{
 			"version": c.Version,
-			"git_sha": c.GitSHA[len(c.GitSHA)-6:], // Log only the last 6 digits of the Git SHA
+			"git_sha": c.GitSHA[:6], // Log only the first 6 digits of the Git SHA
 		},
 		Cores: []zapcore.Core{&sentry.Core{LevelEnabler: zap.InfoLevel}},
 	}


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/PMP-542

**Description**
Use first 6 chars of git sha when logging to be consistent w/ git's own abbreviated commits (which gh uses, also).
