### PR TITLE
Allow h2c connection upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/uber/jaeger-lib v2.0.0+incompatible // indirect
 	go.uber.org/zap v1.14.1
 	golang.org/x/crypto v0.0.0-20200210222208-86ce3cb69678 // indirect
+	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	golang.org/x/sys v0.0.0-20200107162124-548cf772de50 // indirect
 	google.golang.org/appengine v1.6.3 // indirect
 	google.golang.org/genproto v0.0.0-20200108215221-bd8f9a0ef82f // indirect

--- a/http/server.go
+++ b/http/server.go
@@ -28,6 +28,8 @@ import (
 	"github.com/spothero/tools/http/writer"
 	"github.com/spothero/tools/log"
 	"go.uber.org/zap"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 )
 
 // Config contains the configuration necessary for running an HTTP/HTTPS Server.
@@ -105,7 +107,7 @@ func (c Config) NewServer() Server {
 	return Server{
 		httpServer: &http.Server{
 			Addr:         fmt.Sprintf("%s:%d", c.Address, c.Port),
-			Handler:      router,
+			Handler:      h2c.NewHandler(router, &http2.Server{}),
 			ReadTimeout:  time.Duration(c.ReadTimeout) * time.Second,
 			WriteTimeout: time.Duration(c.WriteTimeout) * time.Second,
 		},


### PR DESCRIPTION
This is all that's required to get cleartext HTTP/2 (aka h2c) connections going. By default `net/http` accepts connections over HTTP/2, but only if TLS is enabled.

Internally, the reason we want h2c turned on is so that we can accept both standard HTTP requests as well as gRPC requests over the same Kubernetes ingress.