### PR TITLE
Add package documentation for currency

### DIFF
--- a/currency/doc.go
+++ b/currency/doc.go
@@ -1,0 +1,4 @@
+/*
+Package currency contains utility functions for currencies.
+*/
+package currency

--- a/currency/example_test.go
+++ b/currency/example_test.go
@@ -1,0 +1,9 @@
+package currency
+
+import "fmt"
+
+func ExampleDollarsToPennies() {
+    fmt.Println(DollarsToPennies(19.136, true))
+    // Output: 1914
+}
+

--- a/currency/example_test.go
+++ b/currency/example_test.go
@@ -6,4 +6,3 @@ func ExampleDollarsToPennies() {
     fmt.Println(DollarsToPennies(19.136, true))
     // Output: 1914
 }
-


### PR DESCRIPTION
Use `currency` as a first example of how we want to do package documentation.


