### PR TITLE
Add pagination package documentation

### DIFF
--- a/pagination/doc.go
+++ b/pagination/doc.go
@@ -1,0 +1,2 @@
+// Package Pagination provides a simple pagination inteface for ordered items with string IDs.
+package pagination

--- a/pagination/example_test.go
+++ b/pagination/example_test.go
@@ -10,6 +10,7 @@ func (o Thing) ExtractID() string {
 	return string(o)
 }
 
+// ExamplePagination is an exmple
 func ExamplePagination() {
 	pages := []Pageable{
 		Thing("foo"),
@@ -22,5 +23,5 @@ func ExamplePagination() {
 	page := GetPageAfterID(pages, "bar", 2)
 
 	fmt.Printf("%v", page)
-	//Output: [baz, boo]
+	//Output: [baz boo]
 }

--- a/pagination/example_test.go
+++ b/pagination/example_test.go
@@ -1,0 +1,26 @@
+package pagination
+
+import (
+    "fmt"
+)
+
+type Thing string
+
+func (o Thing) ExtractID() string {
+  return string(o)
+}
+
+func ExamplePagination() {
+  pages := []Pageable { 
+  Thing("foo"),
+  Thing("bar"),
+  Thing("baz"),
+  Thing("boo"),
+  Thing("bla"),
+  }
+
+  page := GetPageAfterID(pages, "bar", 2)
+
+  fmt.Printf("%v", page)
+  //Output: [baz, boo]
+}

--- a/pagination/example_test.go
+++ b/pagination/example_test.go
@@ -1,26 +1,26 @@
 package pagination
 
 import (
-    "fmt"
+	"fmt"
 )
 
 type Thing string
 
 func (o Thing) ExtractID() string {
-  return string(o)
+	return string(o)
 }
 
 func ExamplePagination() {
-  pages := []Pageable { 
-  Thing("foo"),
-  Thing("bar"),
-  Thing("baz"),
-  Thing("boo"),
-  Thing("bla"),
-  }
+	pages := []Pageable{
+		Thing("foo"),
+		Thing("bar"),
+		Thing("baz"),
+		Thing("boo"),
+		Thing("bla"),
+	}
 
-  page := GetPageAfterID(pages, "bar", 2)
+	page := GetPageAfterID(pages, "bar", 2)
 
-  fmt.Printf("%v", page)
-  //Output: [baz, boo]
+	fmt.Printf("%v", page)
+	//Output: [baz, boo]
 }

--- a/pagination/paginator.go
+++ b/pagination/paginator.go
@@ -1,10 +1,5 @@
 package pagination
 
-// IDExtractor extracts an ID from an untyped parameter. It's expected that
-// IDExtractors will downcast element to the expected type and panic if the
-// downcast fails.
-type IDExtractor func(element interface{}) interface{}
-
 func minInt(a, b int) int {
 	if a < b {
 		return a

--- a/pagination/paginator_test.go
+++ b/pagination/paginator_test.go
@@ -18,27 +18,27 @@ func TestMinInt(t *testing.T) {
 	assert := assert.New(t)
 
 	tests := []struct {
-		name        string
-		first int
-		second int
+		name     string
+		first    int
+		second   int
 		expected int
 	}{
 		{
 			name:     "first input is larger",
-			first: 10,
-			second: 20,
+			first:    10,
+			second:   20,
 			expected: 10,
 		},
 		{
 			name:     "second input is larger",
-			first: 20,
-			second: 10,
+			first:    20,
+			second:   10,
 			expected: 10,
 		},
 		{
 			name:     "equal inputs",
-			first: 10,
-			second: 10,
+			first:    10,
+			second:   10,
 			expected: 10,
 		},
 	}


### PR DESCRIPTION
I could not fine anywhere that [IDExtractor](https://godoc.org/github.com/spothero/tools/pagination#IDExtractor) is used.

If it is not used, should we remove it from the package?
