### PR TITLE
Fix lint errors

### DIFF
--- a/currency/example_test.go
+++ b/currency/example_test.go
@@ -3,6 +3,6 @@ package currency
 import "fmt"
 
 func ExampleDollarsToPennies() {
-    fmt.Println(DollarsToPennies(19.136, true))
-    // Output: 1914
+	fmt.Println(DollarsToPennies(19.136, true))
+	// Output: 1914
 }

--- a/log/example_test.go
+++ b/log/example_test.go
@@ -11,7 +11,7 @@ func ExampleConfig() {
 	c := Config{UseDevelopmentLogger: true}
 	err := c.InitializeLogger()
 	fmt.Printf("%v", err)
-	// Output: nil
+	// Output: <nil>
 }
 
 // Create logger

--- a/log/example_test.go
+++ b/log/example_test.go
@@ -1,34 +1,36 @@
 package log
 
 import (
-    "context"
-    "fmt"
-    "net/http"
+	"context"
+	"fmt"
+	"net/http"
 )
 
 // Initialize log package
-func ExampleInitialize() {
-  c := Config{UseDevelopmentLogger: true}
-  c.InitializeLogger()
+func ExampleConfig() {
+	c := Config{UseDevelopmentLogger: true}
+	err := c.InitializeLogger()
+	fmt.Printf("%v", err)
+	// Output: nil
 }
 
 // Create logger
-func ExampleCreate() {
-  logger := Get(context.Background())
-  fmt.Printf("%T", logger)
-  // Output: *zap.Logger
+func ExampleGet() {
+	logger := Get(context.Background())
+	fmt.Printf("%T", logger)
+	// Output: *zap.Logger
 }
 
 // Get logging middleware function for HTTP Server
-func ExampleMiddlewareHTTP() {
-  f := HTTPServerMiddleware
-  fmt.Printf("%T", f)
-  // Output: func(http.Handler) http.Handler
+func ExampleHTTPServerMiddleware() {
+	f := HTTPServerMiddleware
+	fmt.Printf("%T", f)
+	// Output: func(http.Handler) http.Handler
 }
 
 // Get logging http.RoundTripper
 func ExampleRoundTripper() {
-  rt := (http.RoundTripper)(RoundTripper{})
-  fmt.Printf("%T", rt)
-  // Output: log.RoundTripper
+	rt := (http.RoundTripper)(RoundTripper{})
+	fmt.Printf("%T", rt)
+	// Output: log.RoundTripper
 }

--- a/service/doc.go
+++ b/service/doc.go
@@ -1,7 +1,7 @@
 /*
 Package service provides standard configuration and utilities for a service.
 
-Services contain a cli (cobra.Command), http handlers (mux.Router), 
+Services contain a cli (cobra.Command), http handlers (mux.Router),
 a grpc server (grpc.Server), and a metrics interface (prometheus.Registerer).
 */
 package service


### PR DESCRIPTION
Was getting lint errors that were somehow not caught and rejected by the circleci stuff in the first PR: https://github.com/spothero/tools/pull/128

These occur because `go vet` expects Example function names to be valid identifiers in the package.
Seems kinda limited to me.

In addition, forgot to run `go fmt ./...` on a couple files.

```
log/example_test.go:12:21: Error return value of `c.InitializeLogger` is not checked (errcheck)
 + l/example_test.go
  c.InitializeLogger()
                    ^
log/example_test.go:10:1: tests: ExampleInitialize refers to unknown identifier: Initialize (govet)
func ExampleInitialize() {
^
log/example_test.go:16:1: tests: ExampleCreate refers to unknown identifier: Create (govet)
func ExampleCreate() {
^
log/example_test.go:23:1: tests: ExampleMiddlewareHTTP refers to unknown identifier: MiddlewareHTTP (govet)
func ExampleMiddlewareHTTP() {
```
