### PR TITLE
Use // comments in log pkg docs

### DIFF
--- a/log/doc.go
+++ b/log/doc.go
@@ -1,7 +1,4 @@
-/*
-Package log wraps the go.uber.org/zap log package.
-
-It provides methods that attach loggers to middleware, grpc servers, and http.RoundTrippers
-*/
+// Package log wraps the go.uber.org/zap log package.
+// It provides methods that attach loggers to middleware, grpc servers, and http.RoundTrippers
 
 package log


### PR DESCRIPTION
log pkg docs were not showing up here: https://pkg.go.dev/github.com/spothero/tools


Maybe because of package doc comment format ?

Doing a /bump patch so that a new public version is released and is sure to be picked up.
