### PR TITLE
feature/bump-go-version-to-1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run: make lint
   test:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.14
     working_directory: /tmp/tools
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.14
     working_directory: /tmp/tools
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,4 @@ help: ## Prints this help command
 .PHONY: format
 format: ## formats the codebase
 	gofmt -s -w .
+

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spothero/tools
 
-go 1.13
+go 1.14
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.3.3


### PR DESCRIPTION
**Issue Link**
n/a

**Description**
This bumps the go version from 1.13 to 1.14.
