### PR TITLE
feature/SEAR-920-grpc-client-config-max-message-size-options

### DIFF
--- a/grpc/client.go
+++ b/grpc/client.go
@@ -64,7 +64,13 @@ func NewDefaultClientConfig(ctx context.Context) ClientConfig {
 			grpczap.StreamClientInterceptor(log.Get(ctx)),
 			grpcprom.StreamClientInterceptor,
 		},
-		Options: []grpc.DialOption{grpc.WithInsecure()},
+		Options: []grpc.DialOption{
+			grpc.WithInsecure(),
+			grpc.WithDefaultCallOptions(
+				grpc.MaxCallSendMsgSize(maxMessageSizeBytes),
+				grpc.MaxCallRecvMsgSize(maxMessageSizeBytes),
+			),
+		},
 	}
 }
 

--- a/grpc/client_test.go
+++ b/grpc/client_test.go
@@ -39,5 +39,5 @@ func TestGetConn(t *testing.T) {
 	}.GetConn()
 	assert.NoError(t, err)
 	assert.NotNil(t, conn)
-	conn.Close()
+	_ = conn.Close()
 }

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -83,6 +83,7 @@ func (c Config) NewServer() Server {
 			),
 		),
 		grpc.MaxRecvMsgSize(maxMessageSizeBytes),
+		grpc.MaxSendMsgSize(maxMessageSizeBytes),
 	)
 	if c.ServerRegistration == nil {
 		panic("no server registration function provided")


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/SEAR-920

**Description**
This pr passes both send and receive max message size call options to both the grpc client and server default configurations.

I tested this out locally by running availability and facility locally against production kakfa and then running craig locally and pointing at the local running availability and facility services. In addition, I ran the services with this local update using the go.mod replace approach found here: https://thewebivore.com/using-replace-in-go-mod-to-point-to-your-local-module/.

This call fails with the http 500 grpc max message size error in production:
https://api.spothero.com/v2/search/transient/?lat=41.8781&lon=-87.6298&max_distance_meters=160933

But passes locally with a 200:
http://127.0.0.1:8080/v2/search/transient?lat=41.8781&lon=-87.6298&max_distance_meters=160933


