### PR TITLE
Implement schema registry enhancements

### DIFF
--- a/kafka/schema_registry.go
+++ b/kafka/schema_registry.go
@@ -15,6 +15,7 @@
 package kafka
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"encoding/json"
@@ -37,6 +38,22 @@ type SchemaRegistryConfig struct {
 	URL string
 }
 
+type schemaRequest struct {
+	Schema string `json:"schema"`
+}
+
+type schemaResponse struct {
+	Subject string `json:"subject"`
+	Version int    `json:"version"`
+	Schema  string `json:"schema"`
+	ID      int    `json:"id"`
+}
+
+type errorResponse struct {
+	ErrorCode int `json:"error_code"`
+	Message string `json:"message"`
+}
+
 // RegisterFlags registers schema registry flags with pflags
 func (c *SchemaRegistryConfig) RegisterFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&c.URL, "kafka-schema-registry-url", "http://localhost:8081", "Kafka schema registry url")
@@ -50,7 +67,8 @@ func (c *SchemaRegistryConfig) RegisterFlags(flags *pflag.FlagSet) {
 type SchemaRegistryClient struct {
 	SchemaRegistryConfig
 	client http.Client
-	cache  *sync.Map
+	cache  sync.Map
+	cacheLock sync.RWMutex
 }
 
 // NewSchemaRegistryClient creates a schema registry client with the given HTTP metrics bundle.
@@ -75,7 +93,7 @@ func (c SchemaRegistryConfig) NewSchemaRegistryClient(httpMetrics shHTTP.Metrics
 	return SchemaRegistryClient{
 		SchemaRegistryConfig: c,
 		client:               http.Client{Transport: metricsRoundTripper},
-		cache:                &sync.Map{},
+		cache:                sync.Map{},
 	}
 }
 
@@ -83,9 +101,10 @@ func (c SchemaRegistryConfig) NewSchemaRegistryClient(httpMetrics shHTTP.Metrics
 const schemaRegistryAcceptFormat = "application/vnd.schemaregistry.v1+json"
 
 // GetSchema retrieves a textual JSON Avro schema from the Kafka schema registry
-func (c SchemaRegistryClient) GetSchema(ctx context.Context, id uint) (string, error) {
+func (c *SchemaRegistryClient) GetSchema(ctx context.Context, id uint) (string, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "get-avro-schema")
 	defer span.Finish()
+
 	endpoint := fmt.Sprintf("%s/schemas/ids/%d", c.URL, id)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
@@ -98,39 +117,121 @@ func (c SchemaRegistryClient) GetSchema(ctx context.Context, id uint) (string, e
 	}
 	switch response.StatusCode {
 	case http.StatusOK:
-		break
+		var schemaResponse schemaResponse
+		if err := json.NewDecoder(response.Body).Decode(&schemaResponse); err != nil {
+			return "", err
+		}
+		return schemaResponse.Schema, nil
 	case http.StatusNotFound:
 		return "", fmt.Errorf("schema %d not found", id)
 	default:
 		return "", fmt.Errorf(
-			"error while retrieving schema; schema registry returned bad status code %d", response.StatusCode)
+			"error while retrieving schema; schema registry returned unhandled status code %d", response.StatusCode)
 	}
-	var schemaResponse struct {
-		Schema string `json:"schema"`
-	}
-	if err := json.NewDecoder(response.Body).Decode(&schemaResponse); err != nil {
-		return "", err
-	}
-	return schemaResponse.Schema, nil
 }
 
-// DecodeKafkaAvroMessage decodes the given Kafka message encoded with Avro into a Go type.
-func (c SchemaRegistryClient) DecodeKafkaAvroMessage(ctx context.Context, message *sarama.ConsumerMessage) (interface{}, error) {
-	// bytes 1-4 are the schema id (big endian), bytes 5... is the message
-	// see: https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html#wire-format
-	if len(message.Value) < 5 {
-		return nil, fmt.Errorf("no schema id not found in Kafka message")
-	}
-	schemaIDBytes := message.Value[1:5]
-	messageBytes := message.Value[5:]
-	schemaID := uint(binary.BigEndian.Uint32(schemaIDBytes))
+// CheckSchema will check if the schema exists for the given subject
+func (c *SchemaRegistryClient) CheckSchema(ctx context.Context, subject string, schema string, isKey bool) (*schemaResponse, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "check-avro-schema")
+	defer span.Finish()
 
+	concreteSubject := getConcreteSubject(subject, isKey)
+	endpoint := fmt.Sprintf("%s/subjects/%s", c.URL, concreteSubject)
+
+	schemaReq := schemaRequest{Schema: schema}
+	schemaBytes, err := json.Marshal(schemaReq)
+	if err != nil {
+		return nil, err
+	}
+	payload := bytes.NewBuffer(schemaBytes)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build schema registry http request: %w", err)
+	}
+
+	req.Header.Set("Accept", schemaRegistryAcceptFormat)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var schemaResponse = new(schemaResponse)
+		if err := json.NewDecoder(resp.Body).Decode(schemaResponse); err != nil {
+			return nil, err
+		}
+		return schemaResponse, nil
+	case http.StatusNotFound:
+		var errorResponse errorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errorResponse); err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("%s, error code %d", errorResponse.Message, errorResponse.ErrorCode)
+	default:
+		return nil, fmt.Errorf(
+			"error while checking schema; schema registry returned unhandled status code %d", resp.StatusCode)
+	}
+}
+
+// CreateSchema creates a new schema in Schema Registry
+func (c *SchemaRegistryClient) CreateSchema(ctx context.Context, subject string, schema string, isKey bool) (*schemaResponse, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "create-avro-schema")
+	defer span.Finish()
+
+	concreteSubject := getConcreteSubject(subject, isKey)
+	schemaReq := schemaRequest{Schema: schema}
+	endpoint := fmt.Sprintf("%s/subjects/%s/versions", c.URL, concreteSubject)
+	schemaBytes, err := json.Marshal(schemaReq)
+	if err != nil {
+		return nil, err
+	}
+	payload := bytes.NewBuffer(schemaBytes)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", schemaRegistryAcceptFormat)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var schemaResponse = new(schemaResponse)
+		if err := json.NewDecoder(resp.Body).Decode(schemaResponse); err != nil {
+			return nil, err
+		}
+		return schemaResponse, nil
+	case http.StatusConflict:
+		return nil, fmt.Errorf("incompatible schema")
+	case http.StatusUnprocessableEntity:
+		var errorResponse errorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errorResponse); err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("%s, error code %d", errorResponse.Message, errorResponse.ErrorCode)
+	default:
+		return nil, fmt.Errorf(
+			"error while creating schema; schema registry returned unhandled status code %d", resp.StatusCode)
+	}
+}
+
+// GetCodec returns an avro codec based on the provided schema id
+func (c *SchemaRegistryClient) GetCodec(ctx context.Context, id uint) (*goavro.Codec, error) {
 	var codec *goavro.Codec
-	codecIface, ok := c.cache.Load(schemaID)
+	c.cacheLock.RLock()
+	codecIface, ok := c.cache.Load(id)
+	c.cacheLock.RUnlock()
+
 	if ok {
 		codec = codecIface.(*goavro.Codec)
 	} else {
-		schema, err := c.GetSchema(ctx, schemaID)
+		schema, err := c.GetSchema(ctx, id)
 		if err != nil {
 			return nil, err
 		}
@@ -138,12 +239,44 @@ func (c SchemaRegistryClient) DecodeKafkaAvroMessage(ctx context.Context, messag
 		if err != nil {
 			return nil, err
 		}
-		c.cache.Store(schemaID, codec)
+		c.cacheLock.Lock()
+		c.cache.Store(id, codec)
+		c.cacheLock.Unlock()
+	}
+
+	return codec, nil
+}
+
+// DecodeKafkaAvroMessage decodes the given Kafka message encoded with Avro into a Go type.
+func (c *SchemaRegistryClient) DecodeKafkaAvroMessage(ctx context.Context, message *sarama.ConsumerMessage) (interface{}, error) {
+	// bytes 1-4 are the schema id (big endian), bytes 5... is the message
+	// see: https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html#wire-format
+	if len(message.Value) < 5 {
+		return nil, fmt.Errorf("no schema id found in Kafka message")
+	}
+
+	schemaIDBytes := message.Value[1:5]
+	messageBytes := message.Value[5:]
+	schemaID := uint(binary.BigEndian.Uint32(schemaIDBytes))
+
+	codec, err := c.GetCodec(ctx, schemaID)
+	if err != nil {
+		return nil, err
 	}
 
 	decoded, _, err := codec.NativeFromBinary(messageBytes)
 	if err != nil {
 		return nil, err
 	}
+
 	return decoded, nil
+}
+
+func getConcreteSubject(subject string, isKey bool) string {
+	if isKey {
+		subject = fmt.Sprintf("%s-key", subject)
+	} else {
+		subject = fmt.Sprintf("%s-value", subject)
+	}
+	return subject
 }

--- a/kafka/schema_registry.go
+++ b/kafka/schema_registry.go
@@ -68,7 +68,6 @@ type SchemaRegistryClient struct {
 	SchemaRegistryConfig
 	client http.Client
 	cache  sync.Map
-	cacheLock sync.RWMutex
 }
 
 // NewSchemaRegistryClient creates a schema registry client with the given HTTP metrics bundle.
@@ -224,9 +223,7 @@ func (c *SchemaRegistryClient) CreateSchema(ctx context.Context, subject string,
 // GetCodec returns an avro codec based on the provided schema id
 func (c *SchemaRegistryClient) GetCodec(ctx context.Context, id uint) (*goavro.Codec, error) {
 	var codec *goavro.Codec
-	c.cacheLock.RLock()
 	codecIface, ok := c.cache.Load(id)
-	c.cacheLock.RUnlock()
 
 	if ok {
 		codec = codecIface.(*goavro.Codec)
@@ -239,9 +236,7 @@ func (c *SchemaRegistryClient) GetCodec(ctx context.Context, id uint) (*goavro.C
 		if err != nil {
 			return nil, err
 		}
-		c.cacheLock.Lock()
 		c.cache.Store(id, codec)
-		c.cacheLock.Unlock()
 	}
 
 	return codec, nil

--- a/kafka/schema_registry.go
+++ b/kafka/schema_registry.go
@@ -71,7 +71,7 @@ type SchemaRegistryClient struct {
 }
 
 // NewSchemaRegistryClient creates a schema registry client with the given HTTP metrics bundle.
-func (c SchemaRegistryConfig) NewSchemaRegistryClient(httpMetrics shHTTP.Metrics) SchemaRegistryClient {
+func (c SchemaRegistryConfig) NewSchemaRegistryClient(httpMetrics shHTTP.Metrics) *SchemaRegistryClient {
 	retryRoundTripper := shHTTP.RetryRoundTripper{
 		RoundTripper: http.DefaultTransport,
 		RetriableStatusCodes: map[int]bool{
@@ -89,7 +89,7 @@ func (c SchemaRegistryConfig) NewSchemaRegistryClient(httpMetrics shHTTP.Metrics
 	tracingRoundTripper := tracing.RoundTripper{RoundTripper: retryRoundTripper}
 	loggingRoundTripper := log.RoundTripper{RoundTripper: tracingRoundTripper}
 	metricsRoundTripper := shHTTP.MetricsRoundTripper{RoundTripper: loggingRoundTripper, Metrics: httpMetrics}
-	return SchemaRegistryClient{
+	return &SchemaRegistryClient{
 		SchemaRegistryConfig: c,
 		client:               http.Client{Transport: metricsRoundTripper},
 		cache:                sync.Map{},

--- a/kafka/schema_registry.go
+++ b/kafka/schema_registry.go
@@ -67,7 +67,7 @@ func (c *SchemaRegistryConfig) RegisterFlags(flags *pflag.FlagSet) {
 type SchemaRegistryClient struct {
 	SchemaRegistryConfig
 	client http.Client
-	cache  sync.Map
+	cache  *sync.Map
 }
 
 // NewSchemaRegistryClient creates a schema registry client with the given HTTP metrics bundle.
@@ -92,7 +92,7 @@ func (c SchemaRegistryConfig) NewSchemaRegistryClient(httpMetrics shHTTP.Metrics
 	return &SchemaRegistryClient{
 		SchemaRegistryConfig: c,
 		client:               http.Client{Transport: metricsRoundTripper},
-		cache:                sync.Map{},
+		cache:                &sync.Map{},
 	}
 }
 

--- a/kafka/schema_registry.go
+++ b/kafka/schema_registry.go
@@ -174,7 +174,10 @@ func (c *SchemaRegistryClient) CheckSchema(ctx context.Context, subject string, 
 	}
 }
 
-// CreateSchema creates a new schema in Schema Registry
+// CreateSchema creates a new schema in Schema Registry.
+// The Schema Registry compares this against existing known schemas.  If this schema matches an existing schema, a new
+// schema will not be created and instead the existing ID will be returned.  This applies even if the schema is assgined
+// only to another subject.
 func (c *SchemaRegistryClient) CreateSchema(ctx context.Context, subject string, schema string, isKey bool) (*schemaResponse, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "create-avro-schema")
 	defer span.Finish()

--- a/kafka/schema_registry_test.go
+++ b/kafka/schema_registry_test.go
@@ -16,9 +16,13 @@ package kafka
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
@@ -31,6 +35,329 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const avroSchema = `{"type": "record", "name": "test", "fields": [{"name": "name", "type": "string"}]}`
+const schemaID = uint(77)
+const schema = "it's a schema"
+
+type expectedRequest struct {
+	url         string
+	method      string
+	requestBody string
+}
+
+type mockTransport struct {
+	mock.Mock
+	t *testing.T
+	expectedRequest expectedRequest
+}
+
+func readerToString(reader io.Reader) string {
+	buf := new(strings.Builder)
+	_, _ = io.Copy(buf, reader)
+	return buf.String()
+}
+
+func buildSchemaRegistryServer(t *testing.T) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		responsePayload := schemaResponse{
+			Subject: "test-subject",
+			Version: 1,
+			Schema:  "test schema",
+			ID:      77,
+		}
+		response, _ := json.Marshal(responsePayload)
+
+		switch req.URL.String() {
+		case "/schemas/ids/77":
+			assert.Equal(t, http.NoBody, req.Body)
+			_, _ = rw.Write(response)
+		case "/schemas/ids/100":
+			resp := errorResponse{
+				ErrorCode: 40403,
+				Message: "Schema not found",
+			}
+			jsonResp, _ := json.Marshal(resp)
+			rw.WriteHeader(http.StatusNotFound)
+			_, _ = rw.Write(jsonResp)
+			assert.Equal(t, http.NoBody, req.Body)
+		case "/schemas/ids/1000":
+			rw.WriteHeader(http.StatusTeapot)
+			assert.Equal(t, http.NoBody, req.Body)
+		case "/schemas/ids/999":
+			_, _ = rw.Write([]byte("not json"))
+			assert.Equal(t, http.NoBody, req.Body)
+		case "/subjects/test-subject-value":
+			_, _ = rw.Write(response)
+			assert.Equal(t, "{\"schema\":\"test schema\"}", readerToString(req.Body))
+		case "/subjects/test-subject-not-found-value":
+			resp := errorResponse{
+				ErrorCode: 40401,
+				Message: "Subject not found.",
+			}
+			jsonResp, _ := json.Marshal(resp)
+			rw.WriteHeader(http.StatusNotFound)
+			_, _ = rw.Write(jsonResp)
+			assert.Equal(t, "{\"schema\":\"test schema\"}", readerToString(req.Body))
+		case "/subjects/test-subject-not-json-value":
+			_, _ = rw.Write([]byte("not json"))
+			assert.Equal(t, "{\"schema\":\"test schema\"}", readerToString(req.Body))
+		case "/subjects/test-subject-unexpected-response-value":
+			rw.WriteHeader(http.StatusTeapot)
+			assert.Equal(t, "{\"schema\":\"test schema\"}", readerToString(req.Body))
+		case "/subjects/test-subject-value/versions":
+			_, _ = rw.Write(response)
+			assert.Equal(t, "{\"schema\":\"test schema\"}", readerToString(req.Body))
+		case "/subjects/test-subject-incompatible-value/versions":
+			rw.WriteHeader(http.StatusConflict)
+			assert.Equal(t, "{\"schema\":\"test schema\"}", readerToString(req.Body))
+		case "/subjects/test-subject-unprocessable-value/versions":
+			resp := errorResponse{
+				ErrorCode: 42201,
+				Message: "Input schema is an invalid Avro schema",
+			}
+			jsonResp, _ := json.Marshal(resp)
+			rw.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = rw.Write(jsonResp)
+			assert.Equal(t, "{\"schema\":\"test schema\"}", readerToString(req.Body))
+		case "/subjects/test-subject-not-json-value/versions":
+			_, _ = rw.Write([]byte("not json"))
+			assert.Equal(t, "{\"schema\":\"test schema\"}", readerToString(req.Body))
+		case "/subjects/test-subject-unexpected-response-value/versions":
+			rw.WriteHeader(http.StatusTeapot)
+			assert.Equal(t, "{\"schema\":\"test schema\"}", readerToString(req.Body))
+		default:
+			assert.Error(t, errors.New("unhandled request"))
+		}
+
+	}))
+}
+
+
+func TestSchemaRegistryClient_GetSchema(t *testing.T) {
+
+	tests := []struct {
+		name              string
+		schemaID          uint
+		schema            string
+		error             string
+		url               string
+	}{
+		{
+			name: "schema is retrieved from schema registry",
+			schemaID: 77,
+			schema: "test schema",
+		},
+		{
+			name: "404 returns error",
+			schemaID: 100,
+			error: "schema 100 not found",
+		}, {
+			name: "non-200 returns error",
+			schemaID: 1000,
+			error: "error while retrieving schema; schema registry returned unhandled status code 418",
+		},
+		{
+			name: "bad json returns error",
+			schemaID: 999,
+			error: "invalid character 'o' in literal null (expecting 'u')",
+		},
+		{
+			name: "invalid url returns error",
+			schemaID: 77,
+			error: "failed to build schema registry http request: parse \"💀:///schemas/ids/77\": first path segment in URL cannot contain colon",
+			url: "💀://",
+		},
+	}
+
+	server := buildSchemaRegistryServer(t)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			url := server.URL
+			if test.url != "" {
+				url = test.url
+			}
+
+			client := SchemaRegistryClient{
+				SchemaRegistryConfig: SchemaRegistryConfig{URL: url},
+				client:               http.Client{},
+				cache:                sync.Map{},
+			}
+
+			schema, err := client.GetSchema(context.Background(), test.schemaID)
+
+			if test.error == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.NotNil(t, err)
+				assert.Equal(t, test.error, err.Error())
+			}
+			assert.Equal(t, test.schema, schema)
+		})
+	}
+}
+
+func TestSchemaRegistryClient_CheckSchema(t *testing.T) {
+
+	tests := []struct {
+		name              string
+		subject           string
+		schema            string
+		error             string
+		url               string
+		schemaResponse    *schemaResponse
+	}{
+		{
+			name: "schema is found in the schema registry",
+			subject: "test-subject",
+			schema: "test schema",
+			schemaResponse: &schemaResponse{
+				"test-subject",
+				1,
+				"test schema",
+				77,
+			},
+		},
+		{
+			name: "subject is not found in the schema registry",
+			subject: "test-subject-not-found",
+			schema: "test schema",
+			error: "Subject not found., error code 40401",
+		},
+		{
+			name: "schema registry returns bad json",
+			subject: "test-subject-not-json",
+			schema: "test schema",
+			error: "invalid character 'o' in literal null (expecting 'u')",
+		},
+		{
+			name: "non-200 returns error",
+			subject: "test-subject-unexpected-response",
+			schema: "test schema",
+			error: "error while checking schema; schema registry returned unhandled status code 418",
+		},
+		{
+			name: "invalid url returns error",
+			subject: "test-subject",
+			schema: "test schema",
+			error: "failed to build schema registry http request: parse \"💀:///subjects/test-subject-value\": first path segment in URL cannot contain colon",
+			url: "💀://",
+		},
+	}
+
+	server := buildSchemaRegistryServer(t)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			url := server.URL
+			if test.url != "" {
+				url = test.url
+			}
+
+			client := SchemaRegistryClient{
+				SchemaRegistryConfig: SchemaRegistryConfig{URL: url},
+				client:               http.Client{},
+				cache:                sync.Map{},
+			}
+
+			schemaResponse, err := client.CheckSchema(context.Background(), test.subject, test.schema, false)
+
+			if test.error == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.NotNil(t, err)
+				assert.Equal(t, test.error, err.Error())
+			}
+			assert.Equal(t, test.schemaResponse, schemaResponse)
+		})
+	}
+}
+
+func TestSchemaRegistryClient_CreateSchema(t *testing.T) {
+
+	tests := []struct {
+		name              string
+		subject           string
+		schema            string
+		error             string
+		url               string
+		schemaResponse    *schemaResponse
+	}{
+		{
+			name: "schema is created in the schema registry",
+			subject: "test-subject",
+			schema: "test schema",
+			schemaResponse: &schemaResponse{
+				"test-subject",
+				1,
+				"test schema",
+				77,
+			},
+		},
+		{
+			name: "schema is not created due to incompatibility",
+			subject: "test-subject-incompatible",
+			schema: "test schema",
+			error: "incompatible schema",
+		},
+		{
+			name: "schema is not created due to incompatibility",
+			subject: "test-subject-unprocessable",
+			schema: "test schema",
+			error: "Input schema is an invalid Avro schema, error code 42201",
+		},
+		{
+			name: "schema registry returns bad json",
+			subject: "test-subject-not-json",
+			schema: "test schema",
+			error: "invalid character 'o' in literal null (expecting 'u')",
+		},
+		{
+			name: "non-200 returns error",
+			subject: "test-subject-unexpected-response",
+			schema: "test schema",
+			error: "error while creating schema; schema registry returned unhandled status code 418",
+		},
+		{
+			name: "invalid url returns error",
+			subject: "test-subject",
+			schema: "test schema",
+			error: "parse \"💀:///subjects/test-subject-value/versions\": first path segment in URL cannot contain colon",
+			url: "💀://",
+		},
+	}
+
+	server := buildSchemaRegistryServer(t)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			url := server.URL
+			if test.url != "" {
+				url = test.url
+			}
+
+			client := SchemaRegistryClient{
+				SchemaRegistryConfig: SchemaRegistryConfig{URL: url},
+				client:               http.Client{},
+				cache:                sync.Map{},
+			}
+
+			schemaResponse, err := client.CreateSchema(context.Background(), test.subject, test.schema, false)
+
+			if test.error == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.NotNil(t, err)
+				assert.Equal(t, test.error, err.Error())
+			}
+			assert.Equal(t, test.schemaResponse, schemaResponse)
+		})
+	}
+}
+
 func TestSchemaRegistryConfig_RegisterFlags(t *testing.T) {
 	flags := pflag.NewFlagSet("pflags", pflag.PanicOnError)
 	c := SchemaRegistryConfig{}
@@ -40,115 +367,27 @@ func TestSchemaRegistryConfig_RegisterFlags(t *testing.T) {
 	assert.Equal(t, "http://schema.registry", c.URL)
 }
 
-type mockTransport struct {
-	mock.Mock
-	t *testing.T
+func expectedRequestEmpty() expectedRequest {
+	return expectedRequest{
+		"schema.registry/schemas/ids/77",
+		http.MethodGet,
+		"",
+	}
 }
-
-const schemaID = uint(77)
 
 func (m *mockTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 	call := m.Called(request)
 	m.t.Helper()
 	assert.Equal(m.t, "application/vnd.schemaregistry.v1+json", request.Header.Get("Accept"))
-	assert.Equal(m.t, "schema.registry/schemas/ids/77", request.URL.String())
+	assert.Equal(m.t, m.expectedRequest.url, request.URL.String())
+	assert.Equal(m.t, m.expectedRequest.method, request.Method)
+	if m.expectedRequest.requestBody == "" {
+		assert.Nil(m.t, request.Body)
+	} else {
+		assert.Equal(m.t, m.expectedRequest.requestBody, readerToString(request.Body))
+	}
 	return call.Get(0).(*http.Response), call.Error(1)
 }
-
-func TestSchemaRegistryClient_GetSchema(t *testing.T) {
-	tests := []struct {
-		name              string
-		url               string
-		registryResponse  *http.Response
-		httpErr           bool
-		expectHTTPRequest bool
-		expectedSchema    string
-		expectErr         bool
-	}{
-		{
-			"schema is retrieved from schema registry",
-			"schema.registry",
-			&http.Response{
-				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader("{\"schema\": \"it's a schema\"}")),
-			},
-			false,
-			true,
-			"it's a schema",
-			false,
-		}, {
-			"http error returns error",
-			"schema.registry",
-			&http.Response{},
-			true,
-			true,
-			"",
-			true,
-		}, {
-			"404 returns error",
-			"schema.registry",
-			&http.Response{StatusCode: http.StatusNotFound},
-			false,
-			true,
-			"",
-			true,
-		}, {
-			"non-200 returns error",
-			"schema.registry",
-			&http.Response{StatusCode: http.StatusTeapot},
-			false,
-			true,
-			"",
-			true,
-		}, {
-			"bad json returns error",
-			"schema.registry",
-			&http.Response{
-				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader("not json")),
-			},
-			false,
-			true,
-			"",
-			true,
-		}, {
-			"error building request returns error",
-			"💀://",
-			nil,
-			false,
-			false,
-			"",
-			true,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			client := SchemaRegistryClient{
-				SchemaRegistryConfig: SchemaRegistryConfig{URL: test.url},
-				client:               http.Client{Transport: &mockTransport{t: t}},
-				cache:                &sync.Map{},
-			}
-			if test.expectHTTPRequest {
-				mockCall := client.client.Transport.(*mockTransport).On("RoundTrip", mock.Anything)
-				if test.httpErr {
-					mockCall.Return(test.registryResponse, fmt.Errorf("http error"))
-				} else {
-					mockCall.Return(test.registryResponse, nil)
-				}
-				defer client.client.Transport.(*mockTransport).AssertExpectations(t)
-			}
-			schema, err := client.GetSchema(context.Background(), schemaID)
-			if test.expectErr {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
-			assert.Equal(t, test.expectedSchema, schema)
-		})
-	}
-}
-
-const avroSchema = `{"type": "record", "name": "test", "fields": [{"name": "name", "type": "string"}]}`
 
 func newAvroMessage(t *testing.T) *sarama.ConsumerMessage {
 	t.Helper()
@@ -221,8 +460,8 @@ func TestSchemaRegistryClient_DecodeKafkaAvroMessage(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			client := SchemaRegistryClient{
 				SchemaRegistryConfig: SchemaRegistryConfig{URL: "schema.registry"},
-				cache:                &sync.Map{},
-				client:               http.Client{Transport: &mockTransport{t: t}},
+				cache:                sync.Map{},
+				client:               http.Client{Transport: &mockTransport{t: t, expectedRequest: expectedRequestEmpty()}},
 			}
 			if test.prePopulateCache {
 				codec, err := goavro.NewCodec(test.schema)

--- a/kafka/schema_registry_test.go
+++ b/kafka/schema_registry_test.go
@@ -37,7 +37,6 @@ import (
 
 const avroSchema = `{"type": "record", "name": "test", "fields": [{"name": "name", "type": "string"}]}`
 const schemaID = uint(77)
-const schema = "it's a schema"
 
 type expectedRequest struct {
 	url         string
@@ -182,7 +181,7 @@ func TestSchemaRegistryClient_GetSchema(t *testing.T) {
 			client := SchemaRegistryClient{
 				SchemaRegistryConfig: SchemaRegistryConfig{URL: url},
 				client:               http.Client{},
-				cache:                sync.Map{},
+				cache:                &sync.Map{},
 			}
 
 			schema, err := client.GetSchema(context.Background(), test.schemaID)
@@ -259,7 +258,7 @@ func TestSchemaRegistryClient_CheckSchema(t *testing.T) {
 			client := SchemaRegistryClient{
 				SchemaRegistryConfig: SchemaRegistryConfig{URL: url},
 				client:               http.Client{},
-				cache:                sync.Map{},
+				cache:                &sync.Map{},
 			}
 
 			schemaResponse, err := client.CheckSchema(context.Background(), test.subject, test.schema, false)
@@ -342,7 +341,7 @@ func TestSchemaRegistryClient_CreateSchema(t *testing.T) {
 			client := SchemaRegistryClient{
 				SchemaRegistryConfig: SchemaRegistryConfig{URL: url},
 				client:               http.Client{},
-				cache:                sync.Map{},
+				cache:                &sync.Map{},
 			}
 
 			schemaResponse, err := client.CreateSchema(context.Background(), test.subject, test.schema, false)
@@ -460,7 +459,7 @@ func TestSchemaRegistryClient_DecodeKafkaAvroMessage(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			client := SchemaRegistryClient{
 				SchemaRegistryConfig: SchemaRegistryConfig{URL: "schema.registry"},
-				cache:                sync.Map{},
+				cache:                &sync.Map{},
 				client:               http.Client{Transport: &mockTransport{t: t, expectedRequest: expectedRequestEmpty()}},
 			}
 			if test.prePopulateCache {

--- a/kafka/unmarshal_test.go
+++ b/kafka/unmarshal_test.go
@@ -266,8 +266,8 @@ func TestConnectAvroUnmarshaller_Unmarshal(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			client := SchemaRegistryClient{
 				SchemaRegistryConfig: SchemaRegistryConfig{URL: "schema.registry"},
-				cache:                &sync.Map{},
-				client:               http.Client{Transport: &mockTransport{t: t}},
+				cache:                sync.Map{},
+				client:               http.Client{Transport: &mockTransport{t: t, expectedRequest: expectedRequestEmpty()}},
 			}
 			getSchema := client.client.Transport.(*mockTransport).On("RoundTrip", mock.Anything)
 			if test.avroDecodeErr {

--- a/kafka/unmarshal_test.go
+++ b/kafka/unmarshal_test.go
@@ -266,7 +266,7 @@ func TestConnectAvroUnmarshaller_Unmarshal(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			client := SchemaRegistryClient{
 				SchemaRegistryConfig: SchemaRegistryConfig{URL: "schema.registry"},
-				cache:                sync.Map{},
+				cache:                &sync.Map{},
 				client:               http.Client{Transport: &mockTransport{t: t, expectedRequest: expectedRequestEmpty()}},
 			}
 			getSchema := client.client.Transport.(*mockTransport).On("RoundTrip", mock.Anything)


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/SIQ-328

**Description**
This change enhances the schema registry client to add support for new APIs:
- CheckSchema: checks if a schema is exists in the registry
- CreateSchema: creates a new schema in the registry
