### PR TITLE
DTS-485 Add tls support for grpc clients

### DIFF
--- a/grpc/client.go
+++ b/grpc/client.go
@@ -50,7 +50,7 @@ func NewDefaultClientConfig(ctx context.Context) ClientConfig {
     return cc
 }
 
-// NewDefaultClientConfig returns the default SpotHero gRPC TLS Client Configuration
+// NewDefaultTLSClientConfig returns the default SpotHero gRPC TLS Client Configuration
 func NewDefaultTLSClientConfig(ctx context.Context) ClientConfig {
     cc := defaultClientConfig(ctx)
     cc.Options = append(cc.Options, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))

--- a/grpc/client_test.go
+++ b/grpc/client_test.go
@@ -31,22 +31,20 @@ func TestNewDefaultClientConfig(t *testing.T) {
 	assert.NotNil(t, cc.Options)
 }
 
+func TestNewDefaultTLSClientConfig(t *testing.T) {
+	cc := NewDefaultTLSClientConfig(context.Background())
+	assert.Equal(t, "localhost", cc.Address)
+	assert.Equal(t, uint16(9111), cc.Port)
+	assert.NotNil(t, cc.UnaryInterceptors)
+	assert.NotNil(t, cc.StreamInterceptors)
+	assert.NotNil(t, cc.Options)
+}
+
 func TestGetConn(t *testing.T) {
 	conn, err := ClientConfig{
 		PropagateAuthHeaders: true,
 		RetryServerErrors:    true,
 		Options:              []grpc.DialOption{grpc.WithInsecure()},
-	}.GetConn()
-	assert.NoError(t, err)
-	assert.NotNil(t, conn)
-	_ = conn.Close()
-}
-func TestGetTLSConn(t *testing.T) {
-	conn, err := ClientConfig{
-		PropagateAuthHeaders: true,
-		RetryServerErrors:    true,
-		TLSEnabled:           true,
-		Options:              []grpc.DialOption{},
 	}.GetConn()
 	assert.NoError(t, err)
 	assert.NotNil(t, conn)

--- a/grpc/client_test.go
+++ b/grpc/client_test.go
@@ -41,3 +41,14 @@ func TestGetConn(t *testing.T) {
 	assert.NotNil(t, conn)
 	_ = conn.Close()
 }
+func TestGetTLSConn(t *testing.T) {
+	conn, err := ClientConfig{
+		PropagateAuthHeaders: true,
+		RetryServerErrors:    true,
+		TLSEnabled:           true,
+		Options:              []grpc.DialOption{},
+	}.GetConn()
+	assert.NoError(t, err)
+	assert.NotNil(t, conn)
+	_ = conn.Close()
+}

--- a/sql/postgres_test.go
+++ b/sql/postgres_test.go
@@ -16,6 +16,7 @@ package sql
 
 import (
 	"testing"
+	"context"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -112,4 +113,10 @@ func TestPostgresConfigBuildConnectionString(t *testing.T) {
 			assert.Equal(t, test.expectedURL, url)
 		})
 	}
+}
+
+func TestErrorConnect(t *testing.T) {
+	config := NewDefaultPostgresConfig("test", "testdb")
+	_, _, err := config.Connect(context.Background())
+    assert.NotNil(t, err)
 }

--- a/sql/postgres_test.go
+++ b/sql/postgres_test.go
@@ -16,7 +16,6 @@ package sql
 
 import (
 	"testing"
-	"context"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -113,10 +112,4 @@ func TestPostgresConfigBuildConnectionString(t *testing.T) {
 			assert.Equal(t, test.expectedURL, url)
 		})
 	}
-}
-
-func TestErrorConnect(t *testing.T) {
-	config := NewDefaultPostgresConfig("test", "testdb")
-	_, _, err := config.Connect(context.Background())
-    assert.NotNil(t, err)
 }


### PR DESCRIPTION
Previously, only insecure default configuration  was available for grpc clients.
This PR provides a default configuration for TLS as well.

In addition to the unit tests, this code has been tested with some [e2e tests](https://github.com/spothero/craig/pull/394/files#diff-80e4f1cfacabf5afef6b0280e94c50e993c08949586151655ea619ff0aa5166aR4189-R4190)