### PR TITLE
SEAR-1239 Add optional CORS middleware for HTTP servers

### DIFF
--- a/cors/cli.go
+++ b/cors/cli.go
@@ -1,0 +1,25 @@
+// Copyright 2021 SpotHero
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cors
+
+import "github.com/spf13/pflag"
+
+// RegisterFlags registers JOSE flags with pflags
+func (c *Config) RegisterFlags(flags *pflag.FlagSet) {
+	flags.BoolVar(&c.EnableMiddleware, "cors-enable-middleware", c.EnableMiddleware, "Specify whether or not CORS middleware is enabled to  enforce policies on cross origin requests")
+	flags.StringVar(&c.AllowedOrigins, "cors-allowed-origins", c.AllowedOrigins, "Specify which origin(s) allow responses to be populated with headers to allow cross origin requests (e.g. \"*\") or \"https://example.com\")")
+	flags.StringVar(&c.AllowedMethods, "cors-allowed-methods", c.AllowedMethods, "Specify which method(s) allow responses to be populated with headers to allow cross origin requests (e.g. \"POST, GET, OPTIONS, PUT, DELETE\")")
+	flags.StringVar(&c.AllowedMethods, "cors-allowed-headers", c.AllowedHeaders, "Specify which header(s) which headers are allowed for cross origin requests (e.g. \"*\" or \"Accept, Content-Type, Content-Length\")")
+}

--- a/cors/cli.go
+++ b/cors/cli.go
@@ -21,5 +21,5 @@ func (c *Config) RegisterFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&c.EnableMiddleware, "cors-enable-middleware", c.EnableMiddleware, "Specify whether or not CORS middleware is enabled to  enforce policies on cross origin requests")
 	flags.StringVar(&c.AllowedOrigins, "cors-allowed-origins", c.AllowedOrigins, "Specify which origin(s) allow responses to be populated with headers to allow cross origin requests (e.g. \"*\") or \"https://example.com\")")
 	flags.StringVar(&c.AllowedMethods, "cors-allowed-methods", c.AllowedMethods, "Specify which method(s) allow responses to be populated with headers to allow cross origin requests (e.g. \"POST, GET, OPTIONS, PUT, DELETE\")")
-	flags.StringVar(&c.AllowedMethods, "cors-allowed-headers", c.AllowedHeaders, "Specify which header(s) which headers are allowed for cross origin requests (e.g. \"*\" or \"Accept, Content-Type, Content-Length\")")
+	flags.StringVar(&c.AllowedHeaders, "cors-allowed-headers", c.AllowedHeaders, "Specify which header(s) are allowed for cross origin requests (e.g. \"*\" or \"Accept, Content-Type, Content-Length\")")
 }

--- a/cors/cli_test.go
+++ b/cors/cli_test.go
@@ -1,0 +1,46 @@
+// Copyright 2021 SpotHero
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cors
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisterFlags(t *testing.T) {
+	flags := pflag.NewFlagSet("pflags", pflag.PanicOnError)
+	c := Config{}
+	c.RegisterFlags(flags)
+	err := flags.Parse(nil)
+	assert.NoError(t, err)
+
+	enableMiddleware, err := flags.GetBool("cors-enable-middleware")
+	assert.NoError(t, err)
+	assert.Equal(t, false, enableMiddleware)
+
+	origins, err := flags.GetString("cors-allowed-origins")
+	assert.NoError(t, err)
+	assert.Equal(t, "", origins)
+
+	methods, err := flags.GetString("cors-allowed-methods")
+	assert.NoError(t, err)
+	assert.Equal(t, "", methods)
+
+	headers, err := flags.GetString("cors-allowed-headers")
+	assert.NoError(t, err)
+	assert.Equal(t, "", headers)
+}

--- a/cors/cors.go
+++ b/cors/cors.go
@@ -1,0 +1,33 @@
+// Copyright 2021 SpotHero
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cors
+
+// Config contains configuration for the cors package
+type Config struct {
+	// EnableMiddleware indicates whether or not CORS middleware is enabled to
+	// enforce policies on cross origin requests
+	EnableMiddleware bool
+	// AllowedOrigins indicates which origins allow responses to be populated
+	// with headers to allow cross origin requests (e.g. "*" or
+	// "https://example.com")
+	AllowedOrigins string
+	// AllowedMethods indicates which methods allow responses to be populated
+	// with headers to allow cross origin requests (e.g. "POST, GET, OPTIONS,
+	// PUT, DELETE")
+	AllowedMethods string
+	// AllowedHeaders indicates which headers are allowed for cross origin
+	// requests (e.g. "*" or "Accept, Content-Type, Content-Length")
+	AllowedHeaders string
+}

--- a/cors/middleware.go
+++ b/cors/middleware.go
@@ -1,0 +1,40 @@
+// Copyright 2021 SpotHero
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cors
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// GetHTTPServerMiddleware returns middleware that adds cors header options to
+// the response and short-circuits further request processing if the request
+// method is OPTIONS.
+func (c Config) GetHTTPServerMiddleware() mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Access-Control-Allow-Origin", c.AllowedOrigins)
+			w.Header().Set("Access-Control-Allow-Methods", c.AllowedMethods)
+			w.Header().Set("Access-Control-Allow-Headers", c.AllowedHeaders)
+			if r.Method == http.MethodOptions {
+				// Downstream handlers do not (yet) have any specific logic for
+				// the OPTIONS method so we can return early.
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/cors/middleware_test.go
+++ b/cors/middleware_test.go
@@ -1,0 +1,85 @@
+// Copyright 2021 SpotHero
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cors
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetHTTPServerMiddleware(t *testing.T) {
+	tests := []struct {
+		name                    string
+		config                  Config
+		httpMethod              string
+		expectedHeaders         map[string]string
+		expectNextHandlerCalled bool
+	}{
+		{
+			"GET request",
+			Config{
+				AllowedOrigins: "*",
+				AllowedMethods: "POST, GET, OPTIONS, PUT, DELETE",
+				AllowedHeaders: "*",
+			},
+			http.MethodGet,
+			map[string]string{
+				"Access-Control-Allow-Origin":  "*",
+				"Access-Control-Allow-Methods": "POST, GET, OPTIONS, PUT, DELETE",
+				"Access-Control-Allow-Headers": "*",
+			},
+			true,
+		}, {
+			"OPTIONS request",
+			Config{},
+			http.MethodOptions,
+			nil,
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testHandlerCalled := false
+			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				testHandlerCalled = true
+			})
+
+			corsMiddleware := test.config.GetHTTPServerMiddleware()
+			testServer := httptest.NewServer(corsMiddleware(testHandler))
+			defer testServer.Close()
+
+			req, err := http.NewRequest(test.httpMethod, testServer.URL, nil)
+			require.NoError(t, err)
+
+			httpRespResult, err := (&http.Client{}).Do(req)
+			require.NoError(t, err)
+			require.NotNil(t, httpRespResult)
+			defer httpRespResult.Body.Close()
+
+			for expectedHeader, expectedValue := range test.expectedHeaders {
+				fmt.Printf("%+v\n", httpRespResult)
+				assert.Equal(t, expectedValue, httpRespResult.Header.Get(expectedHeader))
+			}
+
+			assert.Equal(t, test.expectNextHandlerCalled, testHandlerCalled)
+		})
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -27,6 +27,7 @@ import (
 	grpcprom "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/spf13/cobra"
 	"github.com/spothero/tools/cli"
+	"github.com/spothero/tools/cors"
 	shGRPC "github.com/spothero/tools/grpc"
 	shHTTP "github.com/spothero/tools/http"
 	"github.com/spothero/tools/jose"
@@ -98,6 +99,8 @@ func (c Config) ServerCmd(
 	sc := sentry.Config{AppVersion: c.Version}
 	// Tracing Config
 	tc := tracing.Config{ServiceName: c.Name}
+	// CORS Config
+	cc := cors.Config{}
 	// Jose Config
 	jc := jose.Config{
 		ClaimGenerators: []jose.ClaimGenerator{
@@ -139,6 +142,14 @@ func (c Config) ServerCmd(
 				tracing.StreamServerInterceptor,
 				log.StreamServerInterceptor,
 				grpcprom.StreamServerInterceptor,
+			}
+
+			// Add CORS Middleware
+			if cc.EnableMiddleware {
+				httpConfig.Middleware = append(
+					httpConfig.Middleware,
+					cc.GetHTTPServerMiddleware(),
+				)
 			}
 
 			// Add JOSE Auth interceptors
@@ -228,6 +239,7 @@ func (c Config) ServerCmd(
 	lc.RegisterFlags(flags)
 	sc.RegisterFlags(flags)
 	tc.RegisterFlags(flags)
+	cc.RegisterFlags(flags)
 	jc.RegisterFlags(flags)
 	return cmd
 }


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/SEAR-1239

**Description**
Adds optional CORS middleware for HTTP servers.
