### PR TITLE
Attempt to make currency and log docs visible at pkg.go.dev

### DIFF
--- a/currency/doc.go
+++ b/currency/doc.go
@@ -1,4 +1,2 @@
-/*
-Package currency contains utility functions for currencies.
-*/
+// Package currency contains utility functions for currencies.
 package currency

--- a/log/doc.go
+++ b/log/doc.go
@@ -1,4 +1,3 @@
 // Package log wraps the go.uber.org/zap log package.
 // It provides methods that attach loggers to middleware, grpc servers, and http.RoundTrippers
-
 package log


### PR DESCRIPTION
Some time ago I started adding package documentation.   I noticed that not all of it is showing up at https://pkg.go.dev/github.com/spothero/tools 

This PR tweaks the format in an attempt to get the documentation picked up and searchable by the community.