### PR TITLE
SEAR-1541 Add option to disable Sentry integration

### DIFF
--- a/sentry/core_test.go
+++ b/sentry/core_test.go
@@ -31,9 +31,7 @@ func (sm StringerMock) String() string {
 	return "stringer-mock"
 }
 
-type TransportMock struct {
-	flushCalled bool
-}
+type TransportMock struct{}
 
 func (t TransportMock) Configure(options sentry.ClientOptions) {}
 func (t TransportMock) SendEvent(event *sentry.Event)          {}

--- a/sentry/core_test.go
+++ b/sentry/core_test.go
@@ -39,7 +39,6 @@ func (t TransportMock) Configure(options sentry.ClientOptions) {}
 func (t TransportMock) SendEvent(event *sentry.Event)          {}
 func (t TransportMock) Events() []*sentry.Event                { return nil }
 func (t TransportMock) Flush(timeout time.Duration) bool {
-	t.flushCalled = true
 	return true
 }
 

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -24,17 +24,23 @@ type Config struct {
 	DSN         string
 	Environment string
 	AppVersion  string
+	Enabled     bool
 }
 
 // RegisterFlags registers Sentry flags with pflags
 func (c *Config) RegisterFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&c.DSN, "sentry-dsn", "", "Sentry DSN")
+	flags.BoolVarP(&c.Enabled, "sentry-logger-enabled", "t", true, "Enable Sentry")
 }
 
 // InitializeSentry Initializes the Sentry client. This function should be called as soon as
 // possible after the application configuration is loaded so that sentry
 // is setup.
 func (c Config) InitializeSentry() error {
+	if !c.Enabled {
+		return nil
+	}
+
 	opts := sentry.ClientOptions{
 		Dsn:         c.DSN,
 		Environment: c.Environment,

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -30,7 +30,7 @@ type Config struct {
 // RegisterFlags registers Sentry flags with pflags
 func (c *Config) RegisterFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&c.DSN, "sentry-dsn", "", "Sentry DSN")
-	flags.BoolVarP(&c.Enabled, "sentry-logger-enabled", "t", true, "Enable Sentry")
+	flags.BoolVar(&c.Enabled, "sentry-logger-enabled", true, "Enable Sentry")
 }
 
 // InitializeSentry Initializes the Sentry client. This function should be called as soon as

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -17,6 +17,7 @@ package sentry
 import (
 	"testing"
 
+	"github.com/getsentry/sentry-go"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 )
@@ -34,5 +35,37 @@ func TestConfig(t *testing.T) {
 }
 
 func TestInitializeSentry(t *testing.T) {
-	assert.NoError(t, Config{}.InitializeSentry())
+	tests := []struct {
+		name                string
+		config              Config
+		expectClientCreated bool
+	}{
+		{
+			"successfully initialize sentry",
+			Config{Enabled: true},
+			true,
+		},
+		{
+			"no client created when sentry is disabled",
+			Config{
+				Enabled: false,
+			},
+			false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.NoError(t, test.config.InitializeSentry())
+
+			sentryClient := sentry.CurrentHub().Client()
+			if test.expectClientCreated {
+				assert.NotNil(t, sentryClient)
+			} else {
+				assert.Nil(t, sentryClient)
+			}
+
+			// Reset client
+			sentry.CurrentHub().BindClient(nil)
+		})
+	}
 }

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -32,6 +32,10 @@ func TestConfig(t *testing.T) {
 	dsn, err := flags.GetString("sentry-dsn")
 	assert.NoError(t, err)
 	assert.Equal(t, "", dsn)
+
+	enabled, err := flags.GetBool("sentry-logger-enabled")
+	assert.NoError(t, err)
+	assert.Equal(t, true, enabled)
 }
 
 func TestInitializeSentry(t *testing.T) {


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/SEAR-1541

**Description**
Adds option to disable Sentry integration. Sentry is still enabled by default.
