### PR TITLE
SIQ-531 Add functionality to authorize on scope

### DIFF
--- a/jose/auth0.go
+++ b/jose/auth0.go
@@ -34,10 +34,11 @@ type Auth0Generator struct{}
 // JWTs, ClientID will be populated. For normal User authentication UserID will be populated. Both
 // UserID and ClientID will not be populated together.
 type Auth0Claim struct {
-	ID        string `json:"sub"`
+	ID string `json:"sub"`
 	// Email claims are namespaced to prevent collisions. Hardcoding for now as this will be constant.
 	Email     string `json:"https://api.spothero.com/claims/email"`
 	GrantType string `json:"gty"`
+	Scope     string `json:"scope"`
 }
 
 // New satisfies the ClaimGenerator interface, returning an empty claim for use with JOSE parsing

--- a/jose/auth0_test.go
+++ b/jose/auth0_test.go
@@ -74,22 +74,22 @@ func TestGetClientID(t *testing.T) {
 	}{
 		{
 			name:     "client id present",
-			input:    Auth0Claim{"id", "email", "client-credentials"},
+			input:    Auth0Claim{"id", "email", "client-credentials", ""},
 			expected: "id",
 		},
 		{
 			name:     "user id present",
-			input:    Auth0Claim{"id", "email", "password"},
+			input:    Auth0Claim{"id", "email", "password", ""},
 			expected: "",
 		},
 		{
 			name:     "unknown grant",
-			input:    Auth0Claim{"id", "email", "BoGuS"},
+			input:    Auth0Claim{"id", "email", "BoGuS", ""},
 			expected: "",
 		},
 		{
 			name:     "remove @clients suffix",
-			input:    Auth0Claim{"leeroy-jenkins@clients", "email", "client-credentials"},
+			input:    Auth0Claim{"leeroy-jenkins@clients", "email", "client-credentials", ""},
 			expected: "leeroy-jenkins",
 		},
 	}
@@ -110,22 +110,22 @@ func TestGetUserID(t *testing.T) {
 	}{
 		{
 			name:     "client id present",
-			input:    Auth0Claim{"client-id", "email", "client-credentials"},
+			input:    Auth0Claim{"client-id", "email", "client-credentials", ""},
 			expected: "",
 		},
 		{
 			name:     "user id presented as password",
-			input:    Auth0Claim{"user-id", "email", "password"},
+			input:    Auth0Claim{"user-id", "email", "password", ""},
 			expected: "user-id",
 		},
 		{
 			name:     "user id presented as authorization_code",
-			input:    Auth0Claim{"user-id", "email", "password"},
+			input:    Auth0Claim{"user-id", "email", "password", ""},
 			expected: "user-id",
 		},
 		{
 			name:     "unknown grant",
-			input:    Auth0Claim{"id", "email", "BoGuS"},
+			input:    Auth0Claim{"id", "email", "BoGuS", ""},
 			expected: "",
 		},
 	}

--- a/jose/middleware.go
+++ b/jose/middleware.go
@@ -37,6 +37,7 @@ const (
 	bearerPrefixNotFound = "authorization header did not include bearer prefix"
 	invalidBearerToken   = "bearer token is invalid"
 	cannotFindClaim      = "unable to locate token claim which is required to authorize on scope"
+	missingRequiredScope = "missing required scope"
 )
 
 // GetHTTPServerMiddleware returns an HTTP middleware function which extracts the Authorization
@@ -200,7 +201,7 @@ func EnforceAuthenticationWithAuthorization(next http.HandlerFunc, params AuthPa
 				if !hasScope(requiredScope, scope) {
 					metrics.authFailureCounter.With(labels).Inc()
 					w.Header().Set("WWW-Authenticate", "Bearer")
-					http.Error(w, cannotFindClaim, http.StatusForbidden)
+					http.Error(w, missingRequiredScope, http.StatusForbidden)
 					return
 				}
 			}

--- a/jose/middleware.go
+++ b/jose/middleware.go
@@ -206,6 +206,7 @@ func EnforceAuthenticationWithAuthorization(next http.HandlerFunc, params AuthPa
 
 		hasRequiredScope, message := validateRequiredScope(r, params)
 		if !hasRequiredScope {
+			logger.Debug("authorization enforcement failed on request")
 			metrics.authFailureCounter.With(labels).Inc()
 			w.Header().Set("WWW-Authenticate", "Bearer")
 			http.Error(w, message, http.StatusForbidden)

--- a/jose/middleware.go
+++ b/jose/middleware.go
@@ -164,9 +164,9 @@ func validateRequiredScope(r *http.Request, params AuthParams) error {
 			return fmt.Errorf(cannotFindClaim)
 		}
 
-		scope := strings.Split(claim.Scope, " ")
+		tokenScopes := strings.Split(claim.Scope, " ")
 		for _, requiredScope := range params.requiredScopes {
-			if !hasScope(requiredScope, scope) {
+			if !hasScope(requiredScope, tokenScopes) {
 				return fmt.Errorf(missingRequiredScope)
 			}
 		}

--- a/jose/middleware.go
+++ b/jose/middleware.go
@@ -208,7 +208,6 @@ func EnforceAuthenticationWithAuthorization(next http.HandlerFunc, params AuthPa
 		if !hasRequiredScope {
 			logger.Debug("authorization enforcement failed on request")
 			metrics.authFailureCounter.With(labels).Inc()
-			w.Header().Set("WWW-Authenticate", "Bearer")
 			http.Error(w, message, http.StatusForbidden)
 			return
 		}

--- a/jose/middleware.go
+++ b/jose/middleware.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spothero/tools/http/writer"
 	"github.com/spothero/tools/log"
+	tools_strings "github.com/spothero/tools/strings"
 	"go.uber.org/zap"
 )
 
@@ -166,21 +167,12 @@ func validateRequiredScope(r *http.Request, params AuthParams) error {
 
 		tokenScopes := strings.Split(claim.Scope, " ")
 		for _, requiredScope := range params.requiredScopes {
-			if !hasScope(requiredScope, tokenScopes) {
+			if !tools_strings.StringInSlice(requiredScope, tokenScopes) {
 				return fmt.Errorf(missingRequiredScope)
 			}
 		}
 	}
 	return nil
-}
-
-func hasScope(requiredScope string, scope []string) bool {
-	for i := range scope {
-		if scope[i] == requiredScope {
-			return true
-		}
-	}
-	return false
 }
 
 func EnforceAuthenticationWithAuthorization(next http.HandlerFunc, params AuthParams) http.HandlerFunc {

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -1,0 +1,24 @@
+// Copyright 2021 SpotHero
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strings
+
+func StringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -1,0 +1,53 @@
+// Copyright 2021 SpotHero
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strings
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestStringInSlice(t *testing.T) {
+	tests := []struct {
+		name            string
+		input           string
+		inputSlice      []string
+		expectedOutcome bool
+	}{
+		{
+			"string found in slice returns true",
+			"in-slice",
+			[]string{"test", "test2", "in-slice", "test3"},
+			true,
+		},
+		{
+			"string not matching case returns false",
+			"In-slice",
+			[]string{"test", "test2", "in-slice", "test3"},
+			false,
+		},
+		{
+			"string not in slice returns false",
+			"notInSlice",
+			[]string{"test", "test2", "test3"},
+			false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expectedOutcome, StringInSlice(test.input, test.inputSlice))
+		})
+	}
+}


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/SIQ-531

**Description**
This change will allow authorization against a slice of required scopes.  Each of the required scopes must exist in the scope taken from the token to complete authorization.  
