### PR TITLE
SIQ-531 Fix issue were the requiredScopes field was not exported

### DIFF
--- a/jose/middleware.go
+++ b/jose/middleware.go
@@ -155,18 +155,18 @@ func AuthenticationMiddleware(next http.Handler) http.Handler {
 }
 
 type AuthParams struct {
-	requiredScopes []string
+	RequiredScopes []string
 }
 
 func validateRequiredScope(r *http.Request, params AuthParams) error {
-	if params.requiredScopes != nil {
+	if params.RequiredScopes != nil {
 		claim, err := FromContext(r.Context())
 		if err != nil {
 			return fmt.Errorf(cannotFindClaim)
 		}
 
 		tokenScopes := strings.Split(claim.Scope, " ")
-		for _, requiredScope := range params.requiredScopes {
+		for _, requiredScope := range params.RequiredScopes {
 			if !tools_strings.StringInSlice(requiredScope, tokenScopes) {
 				return fmt.Errorf(missingRequiredScope)
 			}

--- a/jose/middleware_test.go
+++ b/jose/middleware_test.go
@@ -239,7 +239,7 @@ func TestEnforceAuthenticationWithAuthorization(t *testing.T) {
 			requestIsAuthenticated: true,
 			requestHasClaim:        false,
 			expectedAuthSuccess:    false,
-			authParams:             AuthParams{requiredScopes: []string{"update:service"}},
+			authParams:             AuthParams{RequiredScopes: []string{"update:service"}},
 			authClaim:              Auth0Claim{},
 		},
 		{
@@ -247,7 +247,7 @@ func TestEnforceAuthenticationWithAuthorization(t *testing.T) {
 			requestIsAuthenticated: true,
 			requestHasClaim:        true,
 			expectedAuthSuccess:    false,
-			authParams:             AuthParams{requiredScopes: []string{"update:service"}},
+			authParams:             AuthParams{RequiredScopes: []string{"update:service"}},
 			authClaim:              Auth0Claim{Scope: "read:service"},
 		},
 		{
@@ -255,7 +255,7 @@ func TestEnforceAuthenticationWithAuthorization(t *testing.T) {
 			requestIsAuthenticated: true,
 			requestHasClaim:        true,
 			expectedAuthSuccess:    false,
-			authParams:             AuthParams{requiredScopes: []string{"update:service read:service"}},
+			authParams:             AuthParams{RequiredScopes: []string{"update:service read:service"}},
 			authClaim:              Auth0Claim{Scope: "read:service"},
 		},
 		{
@@ -263,7 +263,7 @@ func TestEnforceAuthenticationWithAuthorization(t *testing.T) {
 			requestIsAuthenticated: true,
 			requestHasClaim:        true,
 			expectedAuthSuccess:    true,
-			authParams:             AuthParams{requiredScopes: []string{"update:service"}},
+			authParams:             AuthParams{RequiredScopes: []string{"update:service"}},
 			authClaim:              Auth0Claim{Scope: "update:service"},
 		},
 	}


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/SIQ-531

**Description**
This PR fixes an issue were requiredScopes was not exported making it inaccessible from downstream projects that want to use this functionality.
