### PR TITLE
Avoid SIGABRT on IP lookup macos 12

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -33,7 +33,7 @@ import (
 // variables like "AVAILABILITY_KAFKA_BROKER" and not "KAFKA_BROKER". There is no need to
 // capitalize the prefix name.
 //
-// Note: CLI arguments (eg --address=localhost) will always take precedence over environment variables
+// Note: CLI arguments (eg --address=127.0.0.1) will always take precedence over environment variables
 func CobraBindEnvironmentVariables(prefix string) func(cmd *cobra.Command, _ []string) {
 	// Search for environment values with the given prefix
 	viper.SetEnvPrefix(prefix)

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -63,7 +63,7 @@ func defaultClientConfig(ctx context.Context) ClientConfig {
 	grpcprom.EnableClientStreamSendTimeHistogram()
 	grpcprom.EnableHandlingTimeHistogram()
 	return ClientConfig{
-		Address:              "localhost",
+		Address:              "127.0.0.1",
 		Port:                 9111,
 		PropagateAuthHeaders: false,
 		RetryServerErrors:    false,

--- a/grpc/client_test.go
+++ b/grpc/client_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestNewDefaultClientConfig(t *testing.T) {
 	cc := NewDefaultClientConfig(context.Background())
-	assert.Equal(t, "localhost", cc.Address)
+	assert.Equal(t, "127.0.0.1", cc.Address)
 	assert.Equal(t, uint16(9111), cc.Port)
 	assert.NotNil(t, cc.UnaryInterceptors)
 	assert.NotNil(t, cc.StreamInterceptors)
@@ -33,7 +33,7 @@ func TestNewDefaultClientConfig(t *testing.T) {
 
 func TestNewDefaultTLSClientConfig(t *testing.T) {
 	cc := NewDefaultTLSClientConfig(context.Background())
-	assert.Equal(t, "localhost", cc.Address)
+	assert.Equal(t, "127.0.0.1", cc.Address)
 	assert.Equal(t, uint16(9111), cc.Port)
 	assert.NotNil(t, cc.UnaryInterceptors)
 	assert.NotNil(t, cc.StreamInterceptors)

--- a/kafka/schema_registry.go
+++ b/kafka/schema_registry.go
@@ -56,7 +56,7 @@ type errorResponse struct {
 
 // RegisterFlags registers schema registry flags with pflags
 func (c *SchemaRegistryConfig) RegisterFlags(flags *pflag.FlagSet) {
-	flags.StringVar(&c.URL, "kafka-schema-registry-url", "http://localhost:8081", "Kafka schema registry url")
+	flags.StringVar(&c.URL, "kafka-schema-registry-url", "http://127.0.0.1:8081", "Kafka schema registry url")
 }
 
 // SchemaRegistryProducer defines an interface that contains methods to create schemas and encode kafka messages

--- a/log/log.go
+++ b/log/log.go
@@ -154,7 +154,7 @@ func Get(ctx context.Context) *zap.Logger {
 
 // RegisterLogLevelHandler registers an endpoint handler with the specified router to change the global log level
 // for the application. Once the handler is registered, the log level can be changed with an HTTP PUT request to
-// the endpoint with the desired log level. e.g. curl -X PUT -d '{"level":"debug"}' localhost:8080/loglevel
+// the endpoint with the desired log level. e.g. curl -X PUT -d '{"level":"debug"}' 127.0.0.1:8080/loglevel
 func RegisterLogLevelHandler(router *mux.Router) {
 	router.Handle("/loglevel", globalLogLevel)
 }

--- a/sql/postgres.go
+++ b/sql/postgres.go
@@ -56,7 +56,7 @@ type PostgresConfig struct {
 func NewDefaultPostgresConfig(appName, dbName string) PostgresConfig {
 	return PostgresConfig{
 		ApplicationName: appName,
-		Host:            "localhost",
+		Host:            "127.0.0.1",
 		Port:            5432,
 		Database:        dbName,
 		ConnectTimeout:  defaultTimeout,

--- a/sql/postgres_test.go
+++ b/sql/postgres_test.go
@@ -28,7 +28,7 @@ func TestNewDefaultPostgresConfig(t *testing.T) {
 		NewDefaultPostgresConfig("test", "testdb"),
 		PostgresConfig{
 			ApplicationName: "test",
-			Host:            "localhost",
+			Host:            "127.0.0.1",
 			Port:            5432,
 			Database:        "testdb",
 			ConnectTimeout:  5 * time.Second,
@@ -58,29 +58,29 @@ func TestPostgresConfigBuildConnectionString(t *testing.T) {
 			PostgresConfig{
 				ApplicationName: "test",
 				Database:        "test",
-				Host:            "localhost",
+				Host:            "127.0.0.1",
 				Port:            5432,
 			},
 			false,
-			"postgres://localhost:5432/test?application_name=test&sslmode=disable",
+			"postgres://127.0.0.1:5432/test?application_name=test&sslmode=disable",
 		}, {
 			"username and password are encoded into the URL",
 			PostgresConfig{
 				ApplicationName: "test",
 				Database:        "test",
-				Host:            "localhost",
+				Host:            "127.0.0.1",
 				Port:            5432,
 				Username:        "user",
 				Password:        "pass",
 			},
 			false,
-			"postgres://user:pass@localhost:5432/test?application_name=test&sslmode=disable",
+			"postgres://user:pass@127.0.0.1:5432/test?application_name=test&sslmode=disable",
 		}, {
 			"ssl options are encoded",
 			PostgresConfig{
 				ApplicationName: "test",
 				Database:        "test",
-				Host:            "localhost",
+				Host:            "127.0.0.1",
 				Port:            5432,
 				SSL:             true,
 				SSLCert:         "/ssl/cert/path",
@@ -88,18 +88,18 @@ func TestPostgresConfigBuildConnectionString(t *testing.T) {
 				SSLRootCert:     "/ssl/root/cert/path",
 			},
 			false,
-			"postgres://localhost:5432/test?application_name=test&sslmode=verify-full&sslcert=/ssl/cert/path&sslkey=/ssl/key/path&sslrootcert=/ssl/root/cert/path",
+			"postgres://127.0.0.1:5432/test?application_name=test&sslmode=verify-full&sslcert=/ssl/cert/path&sslkey=/ssl/key/path&sslrootcert=/ssl/root/cert/path",
 		}, {
 			"connect timeout is properly encoded when specified",
 			PostgresConfig{
 				ApplicationName: "test",
 				Database:        "test",
-				Host:            "localhost",
+				Host:            "127.0.0.1",
 				Port:            5432,
 				ConnectTimeout:  3 * time.Second,
 			},
 			false,
-			"postgres://localhost:5432/test?application_name=test&sslmode=disable&connect_timeout=3",
+			"postgres://127.0.0.1:5432/test?application_name=test&sslmode=disable&connect_timeout=3",
 		},
 	}
 	for _, test := range tests {

--- a/tracing/cli.go
+++ b/tracing/cli.go
@@ -24,7 +24,7 @@ func (c *Config) RegisterFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&c.ReporterLogSpans, "tracer-reporter-log-spans", false, "Tracer Reporter Logs Spans")
 	flags.IntVar(&c.ReporterMaxQueueSize, "tracer-reporter-max-queue-size", 100, "Tracer Reporter Max Queue Size")
 	flags.DurationVar(&c.ReporterFlushInterval, "tracer-reporter-flush-interval", 1000000000, "Tracer Reporter Flush Interval in nanoseconds")
-	flags.StringVar(&c.AgentHost, "tracer-agent-host", "localhost", "Tracer Agent Host")
+	flags.StringVar(&c.AgentHost, "tracer-agent-host", "127.0.0.1", "Tracer Agent Host")
 	flags.IntVar(&c.AgentPort, "tracer-agent-port", 5775, "Tracer Agent Port")
 	flags.StringVar(&c.ServiceName, "tracer-service-name", c.ServiceName, "Determines the service name for the Tracer UI")
 }

--- a/tracing/cli_test.go
+++ b/tracing/cli_test.go
@@ -55,7 +55,7 @@ func TestRegisterFlags(t *testing.T) {
 
 	tah, err := flags.GetString("tracer-agent-host")
 	assert.NoError(t, err)
-	assert.Equal(t, "localhost", tah)
+	assert.Equal(t, "127.0.0.1", tah)
 
 	tap, err := flags.GetInt("tracer-agent-port")
 	assert.NoError(t, err)


### PR DESCRIPTION
`make test` was failing on macos 12

See https://github.com/golang/go/issues/41572#issuecomment-700232101 for more info.
