### PR TITLE
DTS-745 Allow extra http and grpc middleware config [DO NOT MERGE]

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -60,7 +60,6 @@ type GRPCService interface {
 // function that should satisfy most use cases.
 //
 // Note that Version and GitSHA *must be specified* before calling this function.
-
 func (c Config) ServerCmd(
 	ctx context.Context,
 	shortDescription, longDescription string,
@@ -77,6 +76,9 @@ func (c Config) ServerCmd(
 		[]grpc.UnaryServerInterceptor{},
 		[]grpc.StreamServerInterceptor{})
 }
+
+// ServerCmdWithExtraMiddlewares is the same as ServerCmd but allows
+// additional configuration for http and grpc middleware
 func (c Config) ServerCmdWithExtraMiddlewares(
 	ctx context.Context,
 	shortDescription, longDescription string,


### PR DESCRIPTION
The purpose of this rather ugly change is to allow the client to specify grpc configuration for newrelic like this:
https://pkg.go.dev/github.com/newrelic/go-agent/_integrations/nrgrpc

Right now, i can't think of a simple way for clients of the library to specify extra middleware for http and grpc services.
One way might be to specify the entire http and grpc config but that would be a considerable amount of code client side.
This way keeps the default config in place.  Using it seems blocked on this issue: https://discuss.newrelic.com/t/go-grpc-server-transactions-monitoring-are-not-showed/184295

This is a bad idea because what if we end up using newrelic and remove jaeger tracing, It would require a refactor then anyway.