### PR TITLE
feature/SEAR-2188-prometheus-stats-authenticated-client

### DIFF
--- a/http/metrics.go
+++ b/http/metrics.go
@@ -16,6 +16,7 @@ package http
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -23,6 +24,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spothero/tools/http/writer"
 )
+
+// AUTHENTICATED_CLIENT_KEY is the key used in the request context to pass the client to metrics
+const AUTHENTICATED_CLIENT_KEY = "authenticated_client"
+
+// UNAUTHENTICATED is the string used when the client is unknown
+const UNAUTHENTICATED = "unauthenticated"
 
 // Metrics is a bundle of prometheus HTTP metrics recorders
 type Metrics struct {
@@ -215,4 +222,12 @@ func (metricsRT MetricsRoundTripper) RoundTrip(r *http.Request) (*http.Response,
 	defer timer.ObserveDuration()
 	resp, err = metricsRT.RoundTripper.RoundTrip(r)
 	return resp, err
+}
+
+func retrieveAuthenticatedClient(r *http.Request) string {
+	authenticatedClient := r.Context().Value(AUTHENTICATED_CLIENT_KEY)
+	if authenticatedClient == nil {
+		return UNAUTHENTICATED
+	}
+	return fmt.Sprintf("%v", authenticatedClient)
 }

--- a/http/metrics.go
+++ b/http/metrics.go
@@ -25,8 +25,12 @@ import (
 	"github.com/spothero/tools/http/writer"
 )
 
-// AUTHENTICATED_CLIENT_KEY is the key used in the request context to pass the client to metrics
-const AUTHENTICATED_CLIENT_KEY = "authenticated_client"
+// ContextKey this type is created to avoid the linting error:
+// SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
+type ContextKey string
+
+// AuthenticatedClientKey is the key used in the request context to pass the client to metrics
+const AuthenticatedClientKey = ContextKey("authenticated_client")
 
 // UNAUTHENTICATED is the string used when the client is unknown
 const UNAUTHENTICATED = "unauthenticated"
@@ -229,7 +233,7 @@ func (metricsRT MetricsRoundTripper) RoundTrip(r *http.Request) (*http.Response,
 }
 
 func retrieveAuthenticatedClient(r *http.Request) string {
-	authenticatedClient := r.Context().Value(AUTHENTICATED_CLIENT_KEY)
+	authenticatedClient := r.Context().Value(AuthenticatedClientKey)
 	if authenticatedClient == nil {
 		return UNAUTHENTICATED
 	}

--- a/http/metrics_test.go
+++ b/http/metrics_test.go
@@ -116,7 +116,7 @@ func TestMiddleware(t *testing.T) {
 	labels := prometheus.Labels{
 		"path":                 "/",
 		"status_code":          "666",
-		"authenticated_client": "unauthenticated",
+		"authenticated_client": UNAUTHENTICATED,
 	}
 
 	// Check duration histogram
@@ -235,7 +235,7 @@ func TestMetricsRoundTrip(t *testing.T) {
 				labels := prometheus.Labels{
 					"path":                 "/path",
 					"status_code":          "200",
-					"authenticated_client": "unauthenticated",
+					"authenticated_client": UNAUTHENTICATED,
 				}
 
 				// Check duration histogram

--- a/http/metrics_test.go
+++ b/http/metrics_test.go
@@ -114,8 +114,9 @@ func TestMiddleware(t *testing.T) {
 
 	// Expected prometheus labels after this request
 	labels := prometheus.Labels{
-		"path":        "/",
-		"status_code": "666",
+		"path":                 "/",
+		"status_code":          "666",
+		"authenticated_client": "unauthenticated",
 	}
 
 	// Check duration histogram
@@ -232,8 +233,9 @@ func TestMetricsRoundTrip(t *testing.T) {
 
 				// Expected prometheus labels after this request
 				labels := prometheus.Labels{
-					"path":        "/path",
-					"status_code": "200",
+					"path":                 "/path",
+					"status_code":          "200",
+					"authenticated_client": "unauthenticated",
 				}
 
 				// Check duration histogram

--- a/http/metrics_test.go
+++ b/http/metrics_test.go
@@ -314,7 +314,7 @@ func TestRetrieveAuthenticatedClient(t *testing.T) {
 	for _, test := range tests {
 		request := http.Request{}
 		if test.client != "" {
-			testContext := context.WithValue(request.Context(), AUTHENTICATED_CLIENT_KEY, test.client)
+			testContext := context.WithValue(request.Context(), AuthenticatedClientKey, test.client)
 			request = *request.WithContext(testContext)
 
 		}

--- a/http/metrics_test.go
+++ b/http/metrics_test.go
@@ -306,9 +306,9 @@ func TestRetrieveAuthenticatedClient(t *testing.T) {
 			expected: "spothero",
 		},
 		{
-			name:     "partner authenticated - lyft",
-			client:   "lyft",
-			expected: "lyft",
+			name:     "partner authenticated",
+			client:   "good_partner",
+			expected: "good_partner",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/SEAR-2188

**Description**
This pr begins to lay the groundwork for producing the dashboards to see metrics by client. 

These two dashboards will be updated to parameterize on the new "authenticated_client" param. 

https://grafana.internal.spothero.com/d/FH0y-uFMz/backend-dashboard?orgId=1
https://grafana.internal.spothero.com/d/gHRLlZhGz/http-endpoints?orgId=1
