### PR TITLE
feature/kafka-build-name-to-certificate

### DIFF
--- a/kafka/client.go
+++ b/kafka/client.go
@@ -67,7 +67,6 @@ func (c *Config) populateSaramaConfig(ctx context.Context) error {
 			Certificates:       []tls.Certificate{cert},
 			InsecureSkipVerify: true,
 		}
-		c.Net.TLS.Config.BuildNameToCertificate()
 		c.Net.TLS.Enable = true
 		if c.TLSCaCrtPath != "" {
 			caCert, err := ioutil.ReadFile(c.TLSCaCrtPath)


### PR DESCRIPTION
**Issue Link**
n/a

**Description**
This removes a deprecated function that was failing on the lint step of the build. 