### PR TITLE
feature/SEAR-2188-move-up-auth-middleware

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -73,7 +73,7 @@ func (c Config) ServerCmd(
 		},
 	}
 	jh := jc.NewJOSE()
-	
+
 	// HTTP Config
 	httpConfig := shHTTP.NewDefaultConfig(c.Name)
 	httpConfig.Middleware = []mux.MiddlewareFunc{
@@ -83,13 +83,6 @@ func (c Config) ServerCmd(
 		log.HTTPServerMiddleware,
 		sentry.NewMiddleware().HTTP,
 	}
-
-	//httpConfig.Middleware = append(
-	//	httpConfig.Middleware,
-	//	jose.GetHTTPServerMiddleware(jh),
-	//)
-	httpConfig.Middleware = httpConfig.Middleware
-
 
 	// GRPC Config
 	// XXX: passing `nil` as newGRPCService is a hack to delay the calling of


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/SEAR-2188

**Description**
This pr moves the http auth middleware above the stats in order to identify the client on metrics.

This takes a concession in that authentication errors won't end up in stats. In addition, the latency piece will not be captured either. 