### PR TITLE
feature/SEAR-2188-auth0-client-name-claim

### DIFF
--- a/http/metrics.go
+++ b/http/metrics.go
@@ -23,8 +23,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spothero/tools/http/writer"
 	"github.com/spothero/tools/jose"
-	"github.com/spothero/tools/log"
-	"go.uber.org/zap"
 )
 
 // UNAUTHENTICATED is the string used when the client is unknown
@@ -228,18 +226,10 @@ func (metricsRT MetricsRoundTripper) RoundTrip(r *http.Request) (*http.Response,
 }
 
 func retrieveAuthenticatedClient(r *http.Request) string {
-	logger := log.Get(r.Context())
-
 	claim, err := jose.FromContext(r.Context())
 	if err != nil {
-		logger.Info("failed to retrieve auth0 claim from request context", zap.Error(err))
 		return UNAUTHENTICATED
 	}
 
-	authenticatedClient := claim.ExtractAuthenticatedClientGroup()
-	if authenticatedClient == "" {
-		return UNAUTHENTICATED
-	}
-
-	return authenticatedClient
+	return claim.ClientName
 }

--- a/http/metrics_test.go
+++ b/http/metrics_test.go
@@ -297,39 +297,17 @@ func TestRetrieveAuthenticatedClient(t *testing.T) {
 		expected   string
 	}{
 		{
-			name:       "base case - no key",
+			name:       "base case - no auth0 claim",
 			auth0Claim: nil,
 			expected:   UNAUTHENTICATED,
 		},
 		{
 			name: "spothero user authenticated - password",
 			auth0Claim: &jose.Auth0Claim{
-				ID:        "123",
-				Email:     "email@gmail.com",
-				GrantType: "password",
-				Scope:     "scope2",
+				ID:         "123",
+				ClientName: "client-application",
 			},
-			expected: jose.SPOTHERO_USER,
-		},
-		{
-			name: "machine authenticated - client credentials",
-			auth0Claim: &jose.Auth0Claim{
-				ID:        "987",
-				Email:     "email",
-				GrantType: "client-credentials",
-				Scope:     "scope20",
-			},
-			expected: jose.PARTNER_MACHINE,
-		},
-		{
-			name: "unexpected grant type",
-			auth0Claim: &jose.Auth0Claim{
-				ID:        "579",
-				Email:     "email",
-				GrantType: "sdafsdafasdfsadfs",
-				Scope:     "scope290",
-			},
-			expected: UNAUTHENTICATED,
+			expected: "client-application",
 		},
 	}
 	for _, test := range tests {

--- a/http/metrics_test.go
+++ b/http/metrics_test.go
@@ -302,7 +302,7 @@ func TestRetrieveAuthenticatedClient(t *testing.T) {
 			expected:   UNAUTHENTICATED,
 		},
 		{
-			name: "spothero user authenticated - password",
+			name: "auth0claim exists",
 			auth0Claim: &jose.Auth0Claim{
 				ID:         "123",
 				ClientName: "client-application",

--- a/jose/auth0.go
+++ b/jose/auth0.go
@@ -42,9 +42,10 @@ type Auth0Generator struct{}
 type Auth0Claim struct {
 	ID string `json:"sub"`
 	// Email claims are namespaced to prevent collisions. Hardcoding for now as this will be constant.
-	Email     string `json:"https://api.spothero.com/claims/email"`
-	GrantType string `json:"gty"`
-	Scope     string `json:"scope"`
+	Email      string `json:"https://api.spothero.com/claims/email"`
+	ClientName string `json:"https://api.spothero.com/claims/clientName"`
+	GrantType  string `json:"gty"`
+	Scope      string `json:"scope"`
 }
 
 // New satisfies the ClaimGenerator interface, returning an empty claim for use with JOSE parsing
@@ -86,14 +87,4 @@ func FromContext(ctx context.Context) (*Auth0Claim, error) {
 	}
 
 	return nil, fmt.Errorf("unable to extract claim from given context")
-}
-
-// ExtractAuthenticatedClientGroup determines the client group from the auth0claim for use in downstream metrics
-func (cc Auth0Claim) ExtractAuthenticatedClientGroup() string {
-	if len(cc.GetUserID()) > 0 {
-		return SPOTHERO_USER
-	} else if len(cc.GetClientID()) > 0 {
-		return PARTNER_MACHINE
-	}
-	return ""
 }

--- a/jose/auth0_test.go
+++ b/jose/auth0_test.go
@@ -74,22 +74,22 @@ func TestGetClientID(t *testing.T) {
 	}{
 		{
 			name:     "client id present",
-			input:    Auth0Claim{"id", "email", "client-credentials", ""},
+			input:    Auth0Claim{ID: "id", Email: "email", GrantType: "client-credentials", Scope: ""},
 			expected: "id",
 		},
 		{
 			name:     "user id present",
-			input:    Auth0Claim{"id", "email", "password", ""},
+			input:    Auth0Claim{ID: "id", Email: "email", GrantType: "password", Scope: ""},
 			expected: "",
 		},
 		{
 			name:     "unknown grant",
-			input:    Auth0Claim{"id", "email", "BoGuS", ""},
+			input:    Auth0Claim{ID: "id", Email: "email", GrantType: "BoGuS", Scope: ""},
 			expected: "",
 		},
 		{
 			name:     "remove @clients suffix",
-			input:    Auth0Claim{"leeroy-jenkins@clients", "email", "client-credentials", ""},
+			input:    Auth0Claim{ID: "leeroy-jenkins@clients", Email: "email", GrantType: "client-credentials", Scope: ""},
 			expected: "leeroy-jenkins",
 		},
 	}
@@ -110,22 +110,22 @@ func TestGetUserID(t *testing.T) {
 	}{
 		{
 			name:     "client id present",
-			input:    Auth0Claim{"client-id", "email", "client-credentials", ""},
+			input:    Auth0Claim{ID: "client-id", Email: "email", GrantType: "client-credentials", Scope: ""},
 			expected: "",
 		},
 		{
 			name:     "user id presented as password",
-			input:    Auth0Claim{"user-id", "email", "password", ""},
+			input:    Auth0Claim{ID: "user-id", Email: "email", GrantType: "password", Scope: ""},
 			expected: "user-id",
 		},
 		{
 			name:     "user id presented as authorization_code",
-			input:    Auth0Claim{"user-id", "email", "password", ""},
+			input:    Auth0Claim{ID: "user-id", Email: "email", GrantType: "password", Scope: ""},
 			expected: "user-id",
 		},
 		{
 			name:     "unknown grant",
-			input:    Auth0Claim{"id", "email", "BoGuS", ""},
+			input:    Auth0Claim{ID: "id", Email: "email", GrantType: "BoGuS", Scope: ""},
 			expected: "",
 		},
 	}
@@ -133,42 +133,6 @@ func TestGetUserID(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual := test.input.GetUserID()
-			assert.Equal(t, test.expected, actual)
-		})
-	}
-}
-
-func TestExtractAuthenticatedClientGroup(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    Auth0Claim
-		expected string
-	}{
-		{
-			name:     "client id present",
-			input:    Auth0Claim{"client-id", "email", "client-credentials", ""},
-			expected: PARTNER_MACHINE,
-		},
-		{
-			name:     "user id presented as password",
-			input:    Auth0Claim{"user-id", "email", "password", ""},
-			expected: SPOTHERO_USER,
-		},
-		{
-			name:     "user id presented as authorization_code",
-			input:    Auth0Claim{"user-id", "email", "password", ""},
-			expected: SPOTHERO_USER,
-		},
-		{
-			name:     "unknown grant",
-			input:    Auth0Claim{"id", "email", "BoGuS", ""},
-			expected: "",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actual := test.input.ExtractAuthenticatedClientGroup()
 			assert.Equal(t, test.expected, actual)
 		})
 	}


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/SEAR-2188

**Description**
In this pr, I use the auth0 claim client name value for metrics authenticated_client.
