### PR TITLE
feature/SEAR-2441-http-request-received-info-log

### DIFF
--- a/log/middleware.go
+++ b/log/middleware.go
@@ -60,7 +60,7 @@ func HTTPServerMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		startTime := time.Now()
 		logger := Get(r.Context()).Named("http").With(getFields(r)...)
-		logger.Debug("http request received")
+		logger.Info("http request received")
 		defer func() {
 			var responseCodeField zap.Field
 			if statusRecorder, ok := w.(*writer.StatusRecorder); ok {


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/SEAR-2441

**Description**
In this pr, the incoming debug http request log is bumped to info so we can get both the incoming and outgoing request logs. 