### PR TITLE
SEAR-3282-add-http-method-to-http-metrics

### DIFF
--- a/http/metrics.go
+++ b/http/metrics.go
@@ -68,7 +68,7 @@ func registerCollector(registry prometheus.Registerer, collector prometheus.Coll
 // then the existing collector will be returned.  But if registration failed for any other reason then
 // the application will panic.
 func NewMetrics(registry prometheus.Registerer, mustRegister bool) Metrics {
-	labels := []string{"path", "authenticated_client"}
+	labels := []string{"path", "authenticated_client", "method"}
 
 	// If the user has not provided a Prometheus Registry, use the global Registry
 	if registry == nil {
@@ -178,6 +178,7 @@ func (m Metrics) Middleware(next http.Handler) http.Handler {
 		labels := prometheus.Labels{
 			"path":                 writer.FetchRoutePathTemplate(r),
 			"authenticated_client": retrieveAuthenticatedClient(r),
+			"method": 				r.Method,
 		}
 		m.requestCounter.With(labels).Inc()
 
@@ -221,6 +222,7 @@ func (metricsRT MetricsRoundTripper) RoundTrip(r *http.Request) (*http.Response,
 				"path":                 r.URL.Path,
 				"status_code":          strconv.Itoa(resp.StatusCode),
 				"authenticated_client": retrieveAuthenticatedClient(r),
+				"method":				r.Method,
 			}
 			metricsRT.Metrics.clientCounter.With(labels).Inc()
 			if contentLengthStr := r.Header.Get("Content-Length"); len(contentLengthStr) > 0 {

--- a/http/metrics.go
+++ b/http/metrics.go
@@ -178,7 +178,7 @@ func (m Metrics) Middleware(next http.Handler) http.Handler {
 		labels := prometheus.Labels{
 			"path":                 writer.FetchRoutePathTemplate(r),
 			"authenticated_client": retrieveAuthenticatedClient(r),
-			"method": 				r.Method,
+			"method":               r.Method,
 		}
 		m.requestCounter.With(labels).Inc()
 
@@ -222,7 +222,7 @@ func (metricsRT MetricsRoundTripper) RoundTrip(r *http.Request) (*http.Response,
 				"path":                 r.URL.Path,
 				"status_code":          strconv.Itoa(resp.StatusCode),
 				"authenticated_client": retrieveAuthenticatedClient(r),
-				"method":				r.Method,
+				"method":               r.Method,
 			}
 			metricsRT.Metrics.clientCounter.With(labels).Inc()
 			if contentLengthStr := r.Header.Get("Content-Length"); len(contentLengthStr) > 0 {

--- a/http/metrics_test.go
+++ b/http/metrics_test.go
@@ -117,7 +117,7 @@ func TestMiddleware(t *testing.T) {
 	labels := prometheus.Labels{
 		"path":                 "/",
 		"authenticated_client": UNAUTHENTICATED,
-		"method": 				"GET",
+		"method":               "GET",
 	}
 	requestCounter, err := metrics.requestCounter.GetMetricWith(labels)
 	assert.NoError(t, err)
@@ -238,7 +238,7 @@ func TestMetricsRoundTrip(t *testing.T) {
 					"path":                 "/path",
 					"status_code":          "200",
 					"authenticated_client": UNAUTHENTICATED,
-					"method": 				"GET",
+					"method":               "GET",
 				}
 
 				// Check duration histogram

--- a/http/metrics_test.go
+++ b/http/metrics_test.go
@@ -117,6 +117,7 @@ func TestMiddleware(t *testing.T) {
 	labels := prometheus.Labels{
 		"path":                 "/",
 		"authenticated_client": UNAUTHENTICATED,
+		"method": 				"GET",
 	}
 	requestCounter, err := metrics.requestCounter.GetMetricWith(labels)
 	assert.NoError(t, err)
@@ -237,6 +238,7 @@ func TestMetricsRoundTrip(t *testing.T) {
 					"path":                 "/path",
 					"status_code":          "200",
 					"authenticated_client": UNAUTHENTICATED,
+					"method": 				"GET",
 				}
 
 				// Check duration histogram


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/SEAR-3282

**Description**
This pr adds method to the http metric labels so that we can analyze them separately.