### PR TITLE
SEAR-3379: generating sentry fingerprint based on error message instead of stack-trace

### DIFF
--- a/sentry/core.go
+++ b/sentry/core.go
@@ -165,12 +165,9 @@ func (c *Core) Write(ent zapcore.Entry, fields []zapcore.Field) error {
 		}
 	}
 
-	// Group logs with the same stack trace together unless there is no
-	// stack trace, then group by message
-	fingerprint := ent.Stack
-	if ent.Stack == "" {
-		fingerprint = ent.Message
-	}
+	// Group logs with the same message
+	fingerprint := ent.Message
+
 	event := sentry.NewEvent()
 	event.Message = ent.Message
 	event.Level = severity


### PR DESCRIPTION
**Issue Link**
[SEAR-3379](https://spothero.atlassian.net/browse/SEAR-3379)

**Description**
- generating sentry fingerprint based on error message instead of stack-trace


[SEAR-3379]: https://spothero.atlassian.net/browse/SEAR-3379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ