### PR TITLE
[MOB-477] Fixes the Auth0Claims for Refresh token

### DIFF
--- a/jose/auth0.go
+++ b/jose/auth0.go
@@ -36,11 +36,11 @@ type Auth0Generator struct{}
 type Auth0Claim struct {
 	ID string `json:"sub"`
 	// Email claims are namespaced to prevent collisions. Hardcoding for now as this will be constant.
-	Email          string `json:"https://api.spothero.com/claims/email"`
-	ClientName     string `json:"https://api.spothero.com/claims/clientName"`
-	GrantType      string `json:"gty"`
-	Scope          string `json:"scope"`
-	ExternalUserID string `json:"https://api.spothero.com/claims/user_id"`
+	Email          string      `json:"https://api.spothero.com/claims/email"`
+	ClientName     string      `json:"https://api.spothero.com/claims/clientName"`
+	GrantType      interface{} `json:"gty"`
+	Scope          string      `json:"scope"`
+	ExternalUserID string      `json:"https://api.spothero.com/claims/user_id"`
 }
 
 // New satisfies the ClaimGenerator interface, returning an empty claim for use with JOSE parsing

--- a/jose/auth0.go
+++ b/jose/auth0.go
@@ -58,7 +58,7 @@ func (cc Auth0Claim) NewContext(ctx context.Context) context.Context {
 // GetClientID returns the ClientID field of the claim if it is present,
 // otherwise the empty string
 func (cc Auth0Claim) GetClientID() string {
-	if reflect.TypeOf(cc.GrantType).Kind() == reflect.Slice {
+	if reflect.TypeOf(cc.GrantType).Kind() == reflect.Slice && reflect.TypeOf(cc.GrantType).Elem().Kind() == reflect.String {
 		for _, grantType := range cc.GrantType.([]string) {
 			if grantType == "client-credentials" {
 				// because Auth0 adds the undesirable suffix of "@clients"
@@ -78,7 +78,7 @@ func (cc Auth0Claim) GetClientID() string {
 // GetUserID returns the UserID field of the claim if it is present, otherwise
 // the empty string
 func (cc Auth0Claim) GetUserID() string {
-	if reflect.TypeOf(cc.GrantType).Kind() == reflect.Slice {
+	if reflect.TypeOf(cc.GrantType).Kind() == reflect.Slice && reflect.TypeOf(cc.GrantType).Elem().Kind() == reflect.String {
 		for _, grantType := range cc.GrantType.([]string) {
 			if grantType == "password" || grantType == "authorization_code" {
 				return cc.ID

--- a/jose/auth0.go
+++ b/jose/auth0.go
@@ -17,6 +17,7 @@ package jose
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 )
 
@@ -57,6 +58,15 @@ func (cc Auth0Claim) NewContext(ctx context.Context) context.Context {
 // GetClientID returns the ClientID field of the claim if it is present,
 // otherwise the empty string
 func (cc Auth0Claim) GetClientID() string {
+	if reflect.TypeOf(cc.GrantType).Kind() == reflect.Slice {
+		for _, grantType := range cc.GrantType.([]string) {
+			if grantType == "client-credentials" {
+				// because Auth0 adds the undesirable suffix of "@clients"
+				return strings.TrimSuffix(cc.ID, "@clients")
+			}
+		}
+	}
+
 	if cc.GrantType == "client-credentials" {
 		// because Auth0 adds the undesirable suffix of "@clients"
 		return strings.TrimSuffix(cc.ID, "@clients")
@@ -68,6 +78,14 @@ func (cc Auth0Claim) GetClientID() string {
 // GetUserID returns the UserID field of the claim if it is present, otherwise
 // the empty string
 func (cc Auth0Claim) GetUserID() string {
+	if reflect.TypeOf(cc.GrantType).Kind() == reflect.Slice {
+		for _, grantType := range cc.GrantType.([]string) {
+			if grantType == "password" || grantType == "authorization_code" {
+				return cc.ID
+			}
+		}
+	}
+
 	if cc.GrantType == "password" || cc.GrantType == "authorization_code" {
 		return cc.ID
 	}

--- a/jose/auth0_test.go
+++ b/jose/auth0_test.go
@@ -70,7 +70,7 @@ func TestGetClientID(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    Auth0Claim
-		expected string
+		expected interface{}
 	}{
 		{
 			name:     "client id present",
@@ -80,6 +80,11 @@ func TestGetClientID(t *testing.T) {
 		{
 			name:     "user id present",
 			input:    Auth0Claim{ID: "id", Email: "email", GrantType: "password", Scope: ""},
+			expected: "",
+		},
+		{
+			name:     "user id present",
+			input:    Auth0Claim{ID: "id", Email: "email", GrantType: []string{"refresh", "password"}, Scope: ""},
 			expected: "",
 		},
 		{
@@ -106,7 +111,7 @@ func TestGetUserID(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    Auth0Claim
-		expected string
+		expected interface{}
 	}{
 		{
 			name:     "client id present",
@@ -121,6 +126,11 @@ func TestGetUserID(t *testing.T) {
 		{
 			name:     "user id presented as authorization_code",
 			input:    Auth0Claim{ID: "user-id", Email: "email", GrantType: "password", Scope: ""},
+			expected: "user-id",
+		},
+		{
+			name:     "user id presented as ['refresh_token', password]",
+			input:    Auth0Claim{ID: "user-id", Email: "email", GrantType: []string{"refresh", "password"}, Scope: ""},
 			expected: "user-id",
 		},
 		{

--- a/jose/auth0_test.go
+++ b/jose/auth0_test.go
@@ -78,6 +78,11 @@ func TestGetClientID(t *testing.T) {
 			expected: "id",
 		},
 		{
+			name:     "client id present when GrantType is slice",
+			input:    Auth0Claim{ID: "id", Email: "email", GrantType: []string{"client-credentials"}, Scope: ""},
+			expected: "id",
+		},
+		{
 			name:     "user id present",
 			input:    Auth0Claim{ID: "id", Email: "email", GrantType: "password", Scope: ""},
 			expected: "",
@@ -118,6 +123,7 @@ func TestGetUserID(t *testing.T) {
 			input:    Auth0Claim{ID: "client-id", Email: "email", GrantType: "client-credentials", Scope: ""},
 			expected: "",
 		},
+
 		{
 			name:     "user id presented as password",
 			input:    Auth0Claim{ID: "user-id", Email: "email", GrantType: "password", Scope: ""},

--- a/jose/auth0_test.go
+++ b/jose/auth0_test.go
@@ -83,13 +83,18 @@ func TestGetClientID(t *testing.T) {
 			expected: "id",
 		},
 		{
-			name:     "user id present",
+			name:     "client id present",
 			input:    Auth0Claim{ID: "id", Email: "email", GrantType: "password", Scope: ""},
 			expected: "",
 		},
 		{
-			name:     "user id present",
+			name:     "client id present with grant type is slice",
 			input:    Auth0Claim{ID: "id", Email: "email", GrantType: []string{"refresh", "password"}, Scope: ""},
+			expected: "",
+		},
+		{
+			name:     "user id presented grant array is unknown element type",
+			input:    Auth0Claim{ID: "user-id", Email: "email", GrantType: []int{1}, Scope: ""},
 			expected: "",
 		},
 		{
@@ -138,6 +143,11 @@ func TestGetUserID(t *testing.T) {
 			name:     "user id presented as ['refresh_token', password]",
 			input:    Auth0Claim{ID: "user-id", Email: "email", GrantType: []string{"refresh", "password"}, Scope: ""},
 			expected: "user-id",
+		},
+		{
+			name:     "user id presented grant array is unknown element type",
+			input:    Auth0Claim{ID: "user-id", Email: "email", GrantType: []int{1}, Scope: ""},
+			expected: "",
 		},
 		{
 			name:     "unknown grant",


### PR DESCRIPTION
**Issue Link**
MOB-477

**Description**
- This Pr fixes the error when `jwt` was trying to unmarshal `gty` auth0 custom claims. In Auth0, when the token is get from the /token API, it comes as a string, but the token from the refresh token comes as an array, i.e ["refresh_token", "password"]. Therefore this PR makes the grant type field an interface in Auth0Claim
