### PR TITLE
ADHOC - Bump up to Go version 1.22.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spothero/tools
 
-go 1.22.2
+go 1.22.4
 
 // exclude vulnerable dependency: github.com/prometheus/client_golang -> github.com/prometheus/common@v0.4.1 -> vulnerable
 // the dependency is unused according to the prometheus maintainers - https://github.com/prometheus/client_golang/issues/836#issuecomment-776831141


### PR DESCRIPTION
**Issue Link**
ADHOC

**Description**
Bumps up to Go version 1.22.4 to address a vulnerability reported by `govulncheck`.

```
govulncheck ./...
Scanning your code and 504 packages across 72 dependent modules for known vulnerabilities...

Vulnerability #1: GO-2024-2887
    Unexpected behavior from Is methods for IPv4-mapped IPv6 addresses in
    net/netip
  More info: https://pkg.go.dev/vuln/GO-2024-2887
  Standard library
    Found in: net/netip@go1.22.3
    Fixed in: net/netip@go1.22.4
    Example traces found:
      #1: kafka/client.go:47:33: kafka.Config.NewClient calls sarama.NewClient, which eventually calls netip.Addr.IsLoopback
      #2: kafka/client.go:47:33: kafka.Config.NewClient calls sarama.NewClient, which eventually calls netip.Addr.IsMulticast

Your code is affected by 1 vulnerability from the Go standard library.
```
