### PR TITLE
ADHOC - Handle Auth0 claims with nil grant types

### DIFF
--- a/jose/auth0.go
+++ b/jose/auth0.go
@@ -58,7 +58,7 @@ func (cc Auth0Claim) NewContext(ctx context.Context) context.Context {
 // GetClientID returns the ClientID field of the claim if it is present,
 // otherwise the empty string
 func (cc Auth0Claim) GetClientID() string {
-	if reflect.TypeOf(cc.GrantType).Kind() == reflect.Slice && reflect.TypeOf(cc.GrantType).Elem().Kind() == reflect.String {
+	if cc.GrantType != nil && reflect.TypeOf(cc.GrantType).Kind() == reflect.Slice && reflect.TypeOf(cc.GrantType).Elem().Kind() == reflect.String {
 		for _, grantType := range cc.GrantType.([]string) {
 			if grantType == "client-credentials" {
 				// because Auth0 adds the undesirable suffix of "@clients"
@@ -78,7 +78,7 @@ func (cc Auth0Claim) GetClientID() string {
 // GetUserID returns the UserID field of the claim if it is present, otherwise
 // the empty string
 func (cc Auth0Claim) GetUserID() string {
-	if reflect.TypeOf(cc.GrantType).Kind() == reflect.Slice && reflect.TypeOf(cc.GrantType).Elem().Kind() == reflect.String {
+	if cc.GrantType != nil && reflect.TypeOf(cc.GrantType).Kind() == reflect.Slice && reflect.TypeOf(cc.GrantType).Elem().Kind() == reflect.String {
 		for _, grantType := range cc.GrantType.([]string) {
 			if grantType == "password" || grantType == "authorization_code" {
 				return cc.ID

--- a/jose/auth0_test.go
+++ b/jose/auth0_test.go
@@ -70,7 +70,7 @@ func TestGetClientID(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    Auth0Claim
-		expected interface{}
+		expected string
 	}{
 		{
 			name:     "client id present",
@@ -107,6 +107,11 @@ func TestGetClientID(t *testing.T) {
 			input:    Auth0Claim{ID: "leeroy-jenkins@clients", Email: "email", GrantType: "client-credentials", Scope: ""},
 			expected: "leeroy-jenkins",
 		},
+		{
+			name:     "empty claim",
+			input:    Auth0Claim{},
+			expected: "",
+		},
 	}
 
 	for _, test := range tests {
@@ -121,7 +126,7 @@ func TestGetUserID(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    Auth0Claim
-		expected interface{}
+		expected string
 	}{
 		{
 			name:     "client id present",
@@ -152,6 +157,11 @@ func TestGetUserID(t *testing.T) {
 		{
 			name:     "unknown grant",
 			input:    Auth0Claim{ID: "id", Email: "email", GrantType: "BoGuS", Scope: ""},
+			expected: "",
+		},
+		{
+			name:     "empty claim",
+			input:    Auth0Claim{},
 			expected: "",
 		},
 	}


### PR DESCRIPTION
**Issue Link**
ADHOC

**Description**
Handles Auth0 claims with `GrantType == nil`
