### PR TITLE
SEAR-3612 Fix linting errors for golangci-lint version 1.59.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 5m
+  timeout: 5m
   tests: true
 
 linters:
@@ -7,7 +7,7 @@ linters:
     - revive
     - gofmt
     - staticcheck
-    - vet
+    - govet
     - misspell
     - ineffassign
     - errcheck
@@ -16,5 +16,7 @@ linters:
 
 linters-settings:
   govet:
-    check-shadowing: true
+    settings:
+      shadow:
+        strict: true
     enable-all: true

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ coverage: test ## Displays test coverage report
 .PHONY: lint
 lint: ## Runs the go code linter
 ifdef LINTER_INSTALLED
-	## golangci-lint run
+	golangci-lint run
 else
 	$(error golangci-lint not found, skipping linting. Installation instructions: https://github.com/golangci/golangci-lint#ci-installation)
 endif

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -127,7 +127,7 @@ func (s Server) Run() (chan bool, error) {
 	}
 	go func() {
 		log.Get(ctx).Info(fmt.Sprintf("grpc server started on %s", s.listenAddress))
-		err := s.server.Serve(listener)
+		err = s.server.Serve(listener)
 		if err != nil {
 			log.Get(ctx).Error("error encountered in grpc server", zap.Error(err))
 		} else {

--- a/http/metrics_test.go
+++ b/http/metrics_test.go
@@ -221,8 +221,8 @@ func TestMetricsRoundTrip(t *testing.T) {
 
 				if test.expectCircuitBreakErr {
 					// Check circuit-breaker counter
-					counter, err := metricsRT.Metrics.circuitBreakerOpen.GetMetricWith(prometheus.Labels{"host": ""})
-					assert.NoError(t, err)
+					counter, counterErr := metricsRT.Metrics.circuitBreakerOpen.GetMetricWith(prometheus.Labels{"host": ""})
+					assert.NoError(t, counterErr)
 					pb := &dto.Metric{}
 					assert.NoError(t, counter.Write(pb))
 					assert.Equal(t, 1, int(pb.Counter.GetValue()))

--- a/http/parsers_test.go
+++ b/http/parsers_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestParseCoordinates(t *testing.T) {
+	assertTest := assert.New(t)
+
 	tests := []struct {
 		name         string
 		url          string
@@ -156,25 +158,25 @@ func TestParseCoordinates(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			assert := assert.New(t)
-
+		t.Run(test.name, func(_ *testing.T) {
 			r, _ := http.NewRequest(http.MethodGet, test.url, strings.NewReader(""))
 			maybeCoords, err := ParseCoordinates(r, test.latFieldName, test.lonFieldName)
-			assert.True((err == nil && test.errStr == "") || err != nil && err.Error() == test.errStr)
-			assert.Equal(test.coords, maybeCoords)
+			assertTest.True((err == nil && test.errStr == "") || err != nil && err.Error() == test.errStr)
+			assertTest.Equal(test.coords, maybeCoords)
 		})
 	}
 }
 
 func TestParseTime(t *testing.T) {
+	assertTest := assert.New(t)
+
 	buildTime := func(isoStr string) time.Time {
-		time, err := time.Parse(time.RFC3339, isoStr)
+		parsedTime, err := time.Parse(time.RFC3339, isoStr)
 		if err != nil {
 			panic(fmt.Sprintf("Could not parse as RFC3339: %v", isoStr))
 		}
 
-		return time
+		return parsedTime
 	}
 
 	tests := []struct {
@@ -236,13 +238,11 @@ func TestParseTime(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			assert := assert.New(t)
-
+		t.Run(test.name, func(_ *testing.T) {
 			r, _ := http.NewRequest(http.MethodGet, test.url, strings.NewReader(""))
 			maybeTime, err := ParseTime(r, test.fieldName, test.layouts)
-			assert.True((err == nil) != test.err)
-			assert.Equal(test.result, maybeTime)
+			assertTest.True((err == nil) != test.err)
+			assertTest.Equal(test.result, maybeTime)
 		})
 	}
 }

--- a/jose/middleware_test.go
+++ b/jose/middleware_test.go
@@ -153,6 +153,8 @@ func TestRoundTrip(t *testing.T) {
 }
 
 func TestEnforceAuthentication(t *testing.T) {
+	assertTest := assert.New(t)
+
 	tests := []struct {
 		name                   string
 		requestIsAuthenticated bool
@@ -177,8 +179,7 @@ func TestEnforceAuthentication(t *testing.T) {
 
 		authenticatedHandler := EnforceAuthentication(handler)
 
-		t.Run(test.name, func(t *testing.T) {
-			assert := assert.New(t)
+		t.Run(test.name, func(_ *testing.T) {
 			reqCtx := context.Background()
 
 			if test.requestIsAuthenticated {
@@ -186,21 +187,23 @@ func TestEnforceAuthentication(t *testing.T) {
 			}
 
 			request, err := http.NewRequestWithContext(reqCtx, "GET", "url", nil)
-			assert.NoError(err)
+			assertTest.NoError(err)
 			responseRecorder := httptest.NewRecorder()
 			authenticatedHandler(responseRecorder, request)
 			actualResponse := responseRecorder.Result()
 
 			if test.expectedAuthSuccess {
-				assert.Equal(http.StatusOK, actualResponse.StatusCode)
+				assertTest.Equal(http.StatusOK, actualResponse.StatusCode)
 			} else {
-				assert.Equal(http.StatusUnauthorized, actualResponse.StatusCode)
+				assertTest.Equal(http.StatusUnauthorized, actualResponse.StatusCode)
 			}
 		})
 	}
 }
 
 func TestEnforceAuthenticationWithAuthorization(t *testing.T) {
+	assertTest := assert.New(t)
+
 	tests := []struct {
 		authClaim              Auth0Claim
 		name                   string
@@ -258,8 +261,7 @@ func TestEnforceAuthenticationWithAuthorization(t *testing.T) {
 
 		authenticatedHandler := EnforceAuthenticationWithAuthorization(handler, test.authParams)
 
-		t.Run(test.name, func(t *testing.T) {
-			assert := assert.New(t)
+		t.Run(test.name, func(_ *testing.T) {
 			reqCtx := context.Background()
 
 			if test.requestIsAuthenticated {
@@ -271,15 +273,15 @@ func TestEnforceAuthenticationWithAuthorization(t *testing.T) {
 			}
 
 			request, err := http.NewRequestWithContext(reqCtx, "GET", "url", nil)
-			assert.NoError(err)
+			assertTest.NoError(err)
 			responseRecorder := httptest.NewRecorder()
 			authenticatedHandler(responseRecorder, request)
 			actualResponse := responseRecorder.Result()
 
 			if test.expectedAuthSuccess {
-				assert.Equal(http.StatusOK, actualResponse.StatusCode)
+				assertTest.Equal(http.StatusOK, actualResponse.StatusCode)
 			} else {
-				assert.Equal(http.StatusForbidden, actualResponse.StatusCode)
+				assertTest.Equal(http.StatusForbidden, actualResponse.StatusCode)
 			}
 		})
 	}

--- a/kafka/client.go
+++ b/kafka/client.go
@@ -69,9 +69,9 @@ func (c *Config) populateSaramaConfig(ctx context.Context) error {
 		}
 		c.Net.TLS.Enable = true
 		if c.TLSCaCrtPath != "" {
-			caCert, err := os.ReadFile(c.TLSCaCrtPath)
-			if err != nil {
-				return fmt.Errorf("failed to load Kafka CA certificate: %w", err)
+			caCert, readErr := os.ReadFile(c.TLSCaCrtPath)
+			if readErr != nil {
+				return fmt.Errorf("failed to load Kafka CA certificate: %w", readErr)
 			}
 			if len(caCert) > 0 {
 				caCertPool := x509.NewCertPool()

--- a/kafka/schema_registry.go
+++ b/kafka/schema_registry.go
@@ -131,7 +131,7 @@ func (c *SchemaRegistryClient) GetSchema(ctx context.Context, id uint) (string, 
 	switch response.StatusCode {
 	case http.StatusOK:
 		var decodedResponse SchemaResponse
-		if err := json.NewDecoder(response.Body).Decode(&decodedResponse); err != nil {
+		if err = json.NewDecoder(response.Body).Decode(&decodedResponse); err != nil {
 			return "", err
 		}
 		return decodedResponse.Schema, nil
@@ -172,13 +172,13 @@ func (c *SchemaRegistryClient) CheckSchema(ctx context.Context, subject string, 
 	switch resp.StatusCode {
 	case http.StatusOK:
 		var schemaResponse = new(SchemaResponse)
-		if err := json.NewDecoder(resp.Body).Decode(schemaResponse); err != nil {
+		if err = json.NewDecoder(resp.Body).Decode(schemaResponse); err != nil {
 			return nil, err
 		}
 		return schemaResponse, nil
 	case http.StatusNotFound:
 		var decodedResponse errorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&decodedResponse); err != nil {
+		if err = json.NewDecoder(resp.Body).Decode(&decodedResponse); err != nil {
 			return nil, err
 		}
 		return nil, fmt.Errorf("%s, error code %d", decodedResponse.Message, decodedResponse.ErrorCode)
@@ -219,7 +219,7 @@ func (c *SchemaRegistryClient) CreateSchema(ctx context.Context, subject string,
 	switch resp.StatusCode {
 	case http.StatusOK:
 		var schemaResponse = new(SchemaResponse)
-		if err := json.NewDecoder(resp.Body).Decode(schemaResponse); err != nil {
+		if err = json.NewDecoder(resp.Body).Decode(schemaResponse); err != nil {
 			return nil, err
 		}
 		return schemaResponse, nil
@@ -227,7 +227,7 @@ func (c *SchemaRegistryClient) CreateSchema(ctx context.Context, subject string,
 		return nil, fmt.Errorf("incompatible schema")
 	case http.StatusUnprocessableEntity:
 		var decodedResponse errorResponse
-		if err := json.NewDecoder(resp.Body).Decode(&decodedResponse); err != nil {
+		if err = json.NewDecoder(resp.Body).Decode(&decodedResponse); err != nil {
 			return nil, err
 		}
 		return nil, fmt.Errorf("%s, error code %d", decodedResponse.Message, decodedResponse.ErrorCode)

--- a/kafka/unmarshal.go
+++ b/kafka/unmarshal.go
@@ -85,42 +85,42 @@ func unmarshalConnectMessageMap(messageMap map[string]interface{}, target interf
 			switch fieldKind {
 			case reflect.Bool:
 				// Booleans come through from Kafka Connect as int32, int64, or actual bools
-				if b, ok := kafkaValue.(int32); ok {
+				if b, int32OK := kafkaValue.(int32); int32OK {
 					field.SetBool(b > 0)
-				} else if b, ok := kafkaValue.(int64); ok {
+				} else if b, int64OK := kafkaValue.(int64); int64OK {
 					field.SetBool(b > 0)
-				} else if b, ok := kafkaValue.(float64); ok {
+				} else if b, float64OK := kafkaValue.(float64); float64OK {
 					field.SetBool(b > 0)
-				} else if b, ok := kafkaValue.(bool); ok {
+				} else if b, boolOK := kafkaValue.(bool); boolOK {
 					field.SetBool(b)
 				} else {
 					err = fmt.Errorf("couldn't set bool field with tag %s", tag)
 				}
 			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 				// Avro only has int32 and int64 values so we just need to check those
-				if i, ok := kafkaValue.(int32); ok {
+				if i, int32OK := kafkaValue.(int32); int32OK {
 					field.SetInt(int64(i))
-				} else if i, ok := kafkaValue.(int64); ok {
+				} else if i, int64OK := kafkaValue.(int64); int64OK {
 					field.SetInt(i)
-				} else if i, ok := kafkaValue.(float64); ok {
+				} else if i, float64OK := kafkaValue.(float64); float64OK {
 					field.SetInt(int64(i))
 				} else {
 					err = fmt.Errorf("couldn't set int field with tag %s", tag)
 				}
 			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-				if i, ok := kafkaValue.(int32); ok {
+				if i, int32OK := kafkaValue.(int32); int32OK {
 					field.SetUint(uint64(i))
-				} else if i, ok := kafkaValue.(int64); ok {
+				} else if i, int64OK := kafkaValue.(int64); int64OK {
 					field.SetUint(uint64(i))
-				} else if i, ok := kafkaValue.(float64); ok {
+				} else if i, float64OK := kafkaValue.(float64); float64OK {
 					field.SetUint(uint64(i))
 				} else {
 					err = fmt.Errorf("couldn't set uint field with tag %s", tag)
 				}
 			case reflect.Float32, reflect.Float64:
-				if i, ok := kafkaValue.(float32); ok {
+				if i, float32OK := kafkaValue.(float32); float32OK {
 					field.SetFloat(float64(i))
-				} else if i, ok := kafkaValue.(float64); ok {
+				} else if i, float64OK := kafkaValue.(float64); float64OK {
 					field.SetFloat(i)
 				} else {
 					err = fmt.Errorf("couldn't set float field with tag %s", tag)
@@ -134,13 +134,13 @@ func unmarshalConnectMessageMap(messageMap map[string]interface{}, target interf
 			case reflect.Struct:
 				if field.Type().String() == "time.Time" {
 					// times are encoded as int64 milliseconds in Avro
-					if t, ok := kafkaValue.(int64); ok {
+					if t, int64OK := kafkaValue.(int64); int64OK {
 						timeVal := time.Unix(0, t*1000000)
 						field.Set(reflect.ValueOf(timeVal))
-					} else if t, ok := kafkaValue.(float64); ok {
+					} else if t, float64OK := kafkaValue.(float64); float64OK {
 						timeVal := time.Unix(0, int64(t)*1000000)
 						field.Set(reflect.ValueOf(timeVal))
-					} else if t, ok := kafkaValue.(string); ok {
+					} else if t, stringOK := kafkaValue.(string); stringOK {
 						// try decoding as RFC3339 time string
 						timeVal, parseErr := time.Parse(time.RFC3339, t)
 						if parseErr == nil {

--- a/pagination/paginator_test.go
+++ b/pagination/paginator_test.go
@@ -15,7 +15,7 @@ func (ts testStruct) ExtractID() string {
 }
 
 func TestMinInt(t *testing.T) {
-	assert := assert.New(t)
+	assertTest := assert.New(t)
 
 	tests := []struct {
 		name     string
@@ -46,13 +46,13 @@ func TestMinInt(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(_ *testing.T) {
 			actual := minInt(test.first, test.second)
-			assert.Equal(actual, test.expected)
+			assertTest.Equal(actual, test.expected)
 		})
 	}
 }
 
 func TestGetPageByID(t *testing.T) {
-	assert := assert.New(t)
+	assertTest := assert.New(t)
 
 	tests := []struct {
 		name        string
@@ -161,11 +161,11 @@ func TestGetPageByID(t *testing.T) {
 
 			var page []Pageable
 			if test.panicString == "" {
-				assert.NotPanics(func() {
+				assertTest.NotPanics(func() {
 					page = GetPageAfterID(elements, test.after, test.pageSize)
 				})
 			} else {
-				assert.PanicsWithValue(test.panicString, func() {
+				assertTest.PanicsWithValue(test.panicString, func() {
 					page = GetPageAfterID(elements, test.after, test.pageSize)
 				})
 			}
@@ -180,7 +180,7 @@ func TestGetPageByID(t *testing.T) {
 				actual[idx] = typed
 			}
 
-			assert.Equal(actual, test.expected)
+			assertTest.Equal(actual, test.expected)
 		})
 	}
 }

--- a/service/service.go
+++ b/service/service.go
@@ -131,7 +131,7 @@ func (c Config) ServerCmd(
 				return err
 			}
 			defer func() {
-				err := shutdown(ctx)
+				err = shutdown(ctx)
 				if err != nil {
 					return
 				}
@@ -191,10 +191,10 @@ func (c Config) ServerCmd(
 			)
 
 			if c.PreStart != nil {
-				var err error
-				ctx, err = c.PreStart(ctx)
-				if err != nil {
-					return err
+				var preStartErr error
+				ctx, preStartErr = c.PreStart(ctx)
+				if preStartErr != nil {
+					return preStartErr
 				}
 			}
 
@@ -207,9 +207,9 @@ func (c Config) ServerCmd(
 				// reference:f9d302c2-df3f-4110-9529-94b0515c4a17
 				// Follow-up: https://spothero.atlassian.net/browse/PMP-402
 				grpcConfig.ServerRegistration = newGRPCService(c).RegisterAPIs
-				grpcDone, err := grpcConfig.NewServer().Run()
-				if err != nil {
-					return err
+				grpcDone, grpcErr := grpcConfig.NewServer().Run()
+				if grpcErr != nil {
+					return grpcErr
 				}
 				wg.Add(1)
 				go func() {
@@ -229,7 +229,7 @@ func (c Config) ServerCmd(
 
 			wg.Wait()
 			if c.PostShutdown != nil {
-				if err := c.PostShutdown(ctx); err != nil {
+				if err = c.PostShutdown(ctx); err != nil {
 					return err
 				}
 			}

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -45,13 +45,13 @@ func TestLoadLocation(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			loc, err := LoadLocation(test.locationName)
+			loc, locErr := LoadLocation(test.locationName)
 			if test.expectedOutcome != nil {
 				assert.Equal(t, test.expectedOutcome, loc)
-				assert.NoError(t, err)
+				assert.NoError(t, locErr)
 				assert.Contains(t, locCache.cache, test.locationName)
 			} else {
-				assert.Error(t, err)
+				assert.Error(t, locErr)
 			}
 		})
 	}

--- a/tracing/middleware_test.go
+++ b/tracing/middleware_test.go
@@ -184,7 +184,7 @@ func TestGetCorrelationID(t *testing.T) {
 		assert.NotNil(t, correlationID)
 		assert.NotEqual(t, "", correlationID)
 
-		ctx := r.Context()
+		ctx = r.Context()
 		_correlationID := GetCorrelationID(ctx)
 		assert.NotNil(t, _correlationID)
 		assert.NotEqual(t, "", _correlationID)

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -74,7 +74,7 @@ func TestConfigureTracer(t *testing.T) {
 				assert.NotNil(t, shutdown)
 				ctx := context.Background()
 				defer func() {
-					if err := shutdown(ctx); err != nil {
+					if err = shutdown(ctx); err != nil {
 						assert.Error(t, err)
 					}
 				}()


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/SEAR-3612

**Description**
This PR fixes all linting errors after upgrading our `golangci-lint` version to `1.59.1`. Depends on https://github.com/spothero/mdw/pull/370
